### PR TITLE
feat: Refactor Client Configuration Interface

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -7,10 +7,10 @@ buildscript {
     }
 
     repositories {
-        mavenCentral { 
+        mavenCentral {
             credentials {
-                username = System.getenv("SONATYPE_USERNAME")
-                password = System.getenv("SONATYPE_PASSWORD")
+                username = System.getenv("SONATYPE_USERNAME") ?: findProperty('ARTIFACTORY_USER')
+                password = System.getenv("SONATYPE_PASSWORD") ?: findProperty('ARTIFACTORY_PASS')
             }
         }
     }
@@ -20,14 +20,14 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.0.20'
     id 'org.jetbrains.dokka' version '1.9.20'
     id 'com.apollographql.apollo3' version '3.8.4'
-    id 'maven-publish' 
+    id 'maven-publish'
 }
 
 repositories {
-    mavenCentral { 
+    mavenCentral {
         credentials {
-            username = System.getenv("SONATYPE_USERNAME")
-            password = System.getenv("SONATYPE_PASSWORD")
+            username = System.getenv("SONATYPE_USERNAME") ?: findProperty('ARTIFACTORY_USER')
+            password = System.getenv("SONATYPE_PASSWORD") ?: findProperty('ARTIFACTORY_PASS')
         }
     }
 }
@@ -76,7 +76,7 @@ subprojects {
 
 publishing {
     repositories {
-        mavenCentral { 
+        mavenCentral {
             credentials {
                 username = System.getenv("SONATYPE_USERNAME")
                 password = System.getenv("SONATYPE_PASSWORD")

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfiguration.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/configuration/ExpediaGroupClientConfiguration.kt
@@ -16,7 +16,6 @@
 package com.expediagroup.sdk.core.configuration
 
 import com.expediagroup.sdk.core.client.ExpediaGroupClient
-import com.expediagroup.sdk.core.configuration.provider.ExpediaGroupConfigurationProvider
 import com.expediagroup.sdk.core.configuration.provider.RuntimeConfigurationProvider
 
 /**
@@ -45,81 +44,4 @@ data class ExpediaGroupClientConfiguration(
 ) : ClientConfiguration {
     /** Build a [RuntimeConfigurationProvider] from an [ExpediaGroupClientConfiguration]. */
     override fun toProvider(): RuntimeConfigurationProvider = super.toProvider().copy(authEndpoint = authEndpoint)
-
-    class Builder {
-        private var key: String? = null
-        private var secret: String? = null
-        private var endpoint: String? = null
-        private var requestTimeout: Long? = null
-        private var connectionTimeout: Long? = null
-        private var socketTimeout: Long? = null
-        private var maskedLoggingHeaders: Set<String>? = null
-        private var maskedLoggingBodyFields: Set<String>? = null
-        private var authEndpoint: String? = null
-
-        fun key(key: String) = apply { this.key = key }
-        fun secret(secret: String) = apply { this.secret = secret }
-        fun endpoint(endpoint: String) = apply { this.endpoint = endpoint }
-        fun requestTimeout(requestTimeout: Long) = apply { this.requestTimeout = requestTimeout }
-        fun connectionTimeout(connectionTimeout: Long) = apply { this.connectionTimeout = connectionTimeout }
-        fun socketTimeout(socketTimeout: Long) = apply { this.socketTimeout = socketTimeout }
-        fun maskedLoggingHeaders(maskedLoggingHeaders: Set<String>) =
-            apply { this.maskedLoggingHeaders = maskedLoggingHeaders }
-
-        fun maskedLoggingBodyFields(maskedLoggingBodyFields: Set<String>) =
-            apply { this.maskedLoggingBodyFields = maskedLoggingBodyFields }
-
-        fun authEndpoint(authEndpoint: String) = apply { this.authEndpoint = authEndpoint }
-
-        private fun fallback() {
-            val provider = ExpediaGroupConfigurationProvider
-
-            if (endpoint == null) {
-                endpoint = provider.endpoint
-            }
-
-            if (requestTimeout == null) {
-                requestTimeout = provider.requestTimeout
-            }
-
-            if (connectionTimeout == null) {
-                connectionTimeout = provider.connectionTimeout
-            }
-
-            if (socketTimeout == null) {
-                socketTimeout = provider.socketTimeout
-            }
-
-            if (maskedLoggingHeaders == null) {
-                maskedLoggingHeaders = provider.maskedLoggingHeaders
-            }
-
-            if (maskedLoggingBodyFields == null) {
-                maskedLoggingBodyFields = provider.maskedLoggingBodyFields
-            }
-        }
-
-        fun build(): ExpediaGroupClientConfiguration {
-            fallback()
-
-            return ExpediaGroupClientConfiguration(
-                key,
-                secret,
-                endpoint,
-                requestTimeout,
-                connectionTimeout,
-                socketTimeout,
-                maskedLoggingHeaders,
-                maskedLoggingBodyFields,
-                authEndpoint
-            )
-        }
-    }
-
-
-    companion object {
-        /** Create a new [ClientConfiguration] builder. */
-        @JvmStatic
-        fun builder(): Builder = Builder()
-    }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientConfiguration.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientConfiguration.kt
@@ -1,0 +1,89 @@
+package com.expediagroup.sdk.lodgingconnectivity.configuration
+
+import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
+
+data class ClientConfiguration(
+    val key: String?,
+    val secret: String?,
+    val environment: ClientEnvironment?,
+    val requestTimeout: Long? = null,
+    val connectionTimeout: Long? = null,
+    val socketTimeout: Long? = null,
+    val maskedLoggingHeaders: Set<String>? = null,
+    val maskedLoggingBodyFields: Set<String>? = null
+) {
+    class Builder {
+        private var key: String? = null
+        private var secret: String? = null
+        private var environment: ClientEnvironment? = null
+        private var requestTimeout: Long? = null
+        private var connectionTimeout: Long? = null
+        private var socketTimeout: Long? = null
+        private var maskedLoggingHeaders: Set<String>? = null
+        private var maskedLoggingBodyFields: Set<String>? = null
+
+        fun key(key: String) = apply {
+            this.key = key
+        }
+
+        fun secret(secret: String) = apply {
+            this.secret = secret
+        }
+
+        fun environment(environment: ClientEnvironment) = apply {
+            this.environment = environment
+        }
+
+        fun requestTimeout(requestTimeout: Long) = apply {
+            this.requestTimeout = requestTimeout
+        }
+
+        fun connectionTimeout(connectionTimeout: Long) = apply {
+            this.connectionTimeout = connectionTimeout
+        }
+
+        fun socketTimeout(socketTimeout: Long) = apply {
+            this.socketTimeout = socketTimeout
+        }
+
+        fun maskedLoggingHeaders(maskedLoggingHeaders: Set<String>) = apply {
+            this.maskedLoggingHeaders = maskedLoggingHeaders
+        }
+
+        fun maskedLoggingBodyFields(maskedLoggingBodyFields: Set<String>) = apply {
+            this.maskedLoggingBodyFields = maskedLoggingBodyFields
+        }
+
+        fun build(): ClientConfiguration {
+            return ClientConfiguration(
+                key,
+                secret,
+                environment,
+                requestTimeout,
+                connectionTimeout,
+                socketTimeout,
+                maskedLoggingHeaders,
+                maskedLoggingBodyFields,
+            )
+        }
+    }
+
+    companion object {
+        /** Create a new [ClientConfiguration] builder. */
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    fun toExpediaGroupClientConfiguration(endpoint: String, authEndpoint: String): ExpediaGroupClientConfiguration =
+        ExpediaGroupClientConfiguration(
+            key,
+            secret,
+            endpoint,
+            requestTimeout,
+            connectionTimeout,
+            socketTimeout,
+            maskedLoggingHeaders,
+            maskedLoggingBodyFields,
+            authEndpoint
+        )
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientConfiguration.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientConfiguration.kt
@@ -74,16 +74,22 @@ data class ClientConfiguration(
         fun builder(): Builder = Builder()
     }
 
-    fun toExpediaGroupClientConfiguration(endpoint: String, authEndpoint: String): ExpediaGroupClientConfiguration =
-        ExpediaGroupClientConfiguration(
-            key,
-            secret,
-            endpoint,
-            requestTimeout,
-            connectionTimeout,
-            socketTimeout,
-            maskedLoggingHeaders,
-            maskedLoggingBodyFields,
-            authEndpoint
+    fun toExpediaGroupClientConfiguration(
+        endpointProvider: (ClientEnvironment) -> String,
+        authEndpointProvider: (ClientEnvironment) -> String
+    ): ExpediaGroupClientConfiguration {
+        val environment = this.environment ?: ClientEnvironment.PROD
+
+        return ExpediaGroupClientConfiguration(
+            key = this.key,
+            secret = this.secret,
+            endpoint = endpointProvider(environment),
+            authEndpoint = authEndpointProvider(environment),
+            requestTimeout = this.requestTimeout,
+            connectionTimeout = this.connectionTimeout,
+            socketTimeout = this.socketTimeout,
+            maskedLoggingHeaders = this.maskedLoggingHeaders,
+            maskedLoggingBodyFields = this.maskedLoggingBodyFields
         )
+    }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientEnvironment.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/ClientEnvironment.kt
@@ -1,0 +1,8 @@
+package com.expediagroup.sdk.lodgingconnectivity.configuration
+
+enum class ClientEnvironment {
+    PROD,
+    TEST,
+    SANDBOX_PROD,
+    SANDBOX_TEST
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/EndpointProvider.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/EndpointProvider.kt
@@ -29,7 +29,7 @@ enum class AuthEndpoint(val url: String) {
     SANDBOX_TEST("https://test-api.expediagroup.com/identity/oauth2/v3/token/")
 }
 
-object EndpointsProvider {
+object EndpointProvider {
     fun getSupplyClientEndpoint(environment: ClientEnvironment): String {
         return try {
             SupplyClientEndpoint.valueOf(environment.name).url

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/EndpointsProvider.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/configuration/EndpointsProvider.kt
@@ -1,0 +1,72 @@
+package com.expediagroup.sdk.lodgingconnectivity.configuration
+
+enum class SupplyClientEndpoint(val url: String) {
+    PROD("https://api.expediagroup.com/supply/lodging/graphql"),
+    TEST("https://test-api.expediagroup.com/supply/lodging/graphql"),
+    SANDBOX_PROD("https://api.sandbox.expediagroup.com/supply/lodging/graphql"),
+    SANDBOX_TEST("https://test-api.sandbox.expediagroup.com/supply/lodging/graphql")
+}
+
+enum class PaymentClientEndpoint(val url: String) {
+    PROD("https://api.expediagroup.com/supply/payments/graphql"),
+    TEST("https://test-api.expediagroup.com/supply/payments/graphql")
+}
+
+enum class SandboxClientEndpoint(val url: String) {
+    PROD("https://api.sandbox.expediagroup.com/supply/lodging-sandbox/graphql"),
+    TEST("https://test-api.sandbox.expediagroup.com/supply/lodging-sandbox/graphql")
+}
+
+enum class FileManagementClientEndpoint(val url: String) {
+    PROD("https://api.expediagroup.com/supply-lodging/v1/files"),
+    TEST("https://test-api.expediagroup.com/supply-lodging/v1/files")
+}
+
+enum class AuthEndpoint(val url: String) {
+    PROD("https://api.expediagroup.com/identity/oauth2/v3/token/"),
+    TEST("https://test-api.expediagroup.com/identity/oauth2/v3/token/"),
+    SANDBOX_PROD("https://api.expediagroup.com/identity/oauth2/v3/token/"),
+    SANDBOX_TEST("https://test-api.expediagroup.com/identity/oauth2/v3/token/")
+}
+
+object EndpointsProvider {
+    fun getSupplyClientEndpoint(environment: ClientEnvironment): String {
+        return try {
+            SupplyClientEndpoint.valueOf(environment.name).url
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Unsupported environment [$environment] for SupplyClient")
+        }
+    }
+
+    fun getPaymentClientEndpoint(environment: ClientEnvironment): String {
+        return try {
+            PaymentClientEndpoint.valueOf(environment.name).url
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Unsupported environment [$environment] for PaymentClient")
+        }
+    }
+
+    fun getSandboxClientEndpoint(environment: ClientEnvironment): String {
+        return try {
+            SandboxClientEndpoint.valueOf(environment.name).url
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Unsupported environment [$environment] for SandboxClient")
+        }
+    }
+
+    fun getFileManagementClientEndpoint(environment: ClientEnvironment): String {
+        return try {
+            FileManagementClientEndpoint.valueOf(environment.name).url
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Unsupported environment [$environment] for FileManagementClient")
+        }
+    }
+
+    fun getAuthEndpoint(environment: ClientEnvironment): String {
+        return try {
+            AuthEndpoint.valueOf(environment.name).url
+        } catch (e: IllegalArgumentException) {
+            throw IllegalArgumentException("Unsupported environment [$environment] for Authentication")
+        }
+    }
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -44,8 +44,8 @@ import java.io.File
  */
 class FileManagementClient(config: ClientConfiguration) :
     ExpediaGroupClient("filemanagement", config.toExpediaGroupClientConfiguration(
-        endpoint = EndpointsProvider.getFileManagementClientEndpoint(config.environment ?: ClientEnvironment.PROD),
-        authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD),
+       endpointProvider = EndpointsProvider::getFileManagementClientEndpoint,
+        authEndpointProvider = EndpointsProvider::getAuthEndpoint
     )) {
     companion object {
         @JvmStatic

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -22,8 +22,7 @@ import com.expediagroup.sdk.core.model.Response
 import com.expediagroup.sdk.core.model.exception.handle
 import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
-import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointProvider
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.Upload201Response
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.exception.*
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -44,8 +43,8 @@ import java.io.File
  */
 class FileManagementClient(config: ClientConfiguration) :
     ExpediaGroupClient("filemanagement", config.toExpediaGroupClientConfiguration(
-       endpointProvider = EndpointsProvider::getFileManagementClientEndpoint,
-        authEndpointProvider = EndpointsProvider::getAuthEndpoint
+       endpointProvider = EndpointProvider::getFileManagementClientEndpoint,
+        authEndpointProvider = EndpointProvider::getAuthEndpoint
     )) {
     companion object {
         @JvmStatic

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -18,38 +18,35 @@ package com.expediagroup.sdk.lodgingconnectivity.filemanagement.client
 
 
 import com.expediagroup.sdk.core.client.ExpediaGroupClient
-import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
 import com.expediagroup.sdk.core.model.Response
 import com.expediagroup.sdk.core.model.exception.handle
 import com.expediagroup.sdk.core.plugin.logging.ExpediaGroupLoggerFactory
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.Upload201Response
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.exception.*
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.ktor.client.plugins.onUpload
-import io.ktor.client.request.forms.MultiPartFormDataContent
-import io.ktor.client.request.forms.formData
-import io.ktor.client.request.prepareRequest
-import io.ktor.client.request.request
-import io.ktor.client.request.url
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
-import io.ktor.util.InternalAPI
-import io.ktor.utils.io.jvm.javaio.toInputStream
-import java.io.File
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.util.*
+import io.ktor.utils.io.jvm.javaio.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
+import java.io.File
 
 /**
  *
  */
-class FileManagementClient(clientConfiguration: ExpediaGroupClientConfiguration) :
-    ExpediaGroupClient("filemanagement", clientConfiguration) {
-
+class FileManagementClient(config: ClientConfiguration) :
+    ExpediaGroupClient("filemanagement", config.toExpediaGroupClientConfiguration(
+        endpoint = EndpointsProvider.getFileManagementClientEndpoint(config.environment ?: ClientEnvironment.PROD),
+        authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD),
+    )) {
     companion object {
         @JvmStatic
         private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -26,13 +26,20 @@ import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointProvider
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.Upload201Response
 import com.expediagroup.sdk.lodgingconnectivity.filemanagement.models.exception.*
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.ktor.client.plugins.*
-import io.ktor.client.request.*
-import io.ktor.client.request.forms.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
-import io.ktor.util.*
-import io.ktor.utils.io.jvm.javaio.*
+import io.ktor.client.plugins.onUpload
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.prepareRequest
+import io.ktor.client.request.request
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.util.InternalAPI
+import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
@@ -42,10 +49,12 @@ import java.io.File
  *
  */
 class FileManagementClient(config: ClientConfiguration) :
-    ExpediaGroupClient("filemanagement", config.toExpediaGroupClientConfiguration(
-       endpointProvider = EndpointProvider::getFileManagementClientEndpoint,
-        authEndpointProvider = EndpointProvider::getAuthEndpoint
-    )) {
+    ExpediaGroupClient(
+        "filemanagement", config.toExpediaGroupClientConfiguration(
+            endpointProvider = EndpointProvider::getFileManagementClientEndpoint,
+            authEndpointProvider = EndpointProvider::getAuthEndpoint
+        )
+    ) {
     companion object {
         @JvmStatic
         private val log = ExpediaGroupLoggerFactory.getLogger(this::class.java)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/BaseGraphQLClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/BaseGraphQLClient.kt
@@ -25,7 +25,7 @@ import com.expediagroup.sdk.core.client.ExpediaGroupClient
 import com.expediagroup.sdk.core.client.KtorHttpEngine
 import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
 import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
-import io.ktor.client.statement.*
+import io.ktor.client.statement.HttpResponse
 import kotlinx.coroutines.runBlocking
 
 class BaseGraphQLClient(config: ExpediaGroupClientConfiguration) : GraphQLExecutor {

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
@@ -16,15 +16,16 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.graphql.payment
 
-import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
-class PaymentClient(config: ExpediaGroupClientConfiguration) :
-    GraphQLExecutor by BaseGraphQLClient
-        .Builder()
-        .key(config.key!!)
-        .secret(config.secret!!)
-        .endpoint("${config.endpoint!!}${if (config.endpoint.endsWith('/')) "" else "/"}supply/payments/graphql")
-        .authEndpoint(config.authEndpoint!!)
-        .build()
+class PaymentClient(config: ClientConfiguration)  :
+    GraphQLExecutor by BaseGraphQLClient(
+        config.toExpediaGroupClientConfiguration(
+            endpoint = EndpointsProvider.getPaymentClientEndpoint(config.environment ?: ClientEnvironment.PROD),
+            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+        )
+    )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.payment
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
 import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
@@ -25,7 +24,7 @@ import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 class PaymentClient(config: ClientConfiguration)  :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpoint = EndpointsProvider.getPaymentClientEndpoint(config.environment ?: ClientEnvironment.PROD),
-            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+            endpointProvider = EndpointsProvider::getPaymentClientEndpoint,
+            authEndpointProvider = EndpointsProvider::getAuthEndpoint
         )
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/payment/PaymentClient.kt
@@ -17,14 +17,14 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.payment
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
 class PaymentClient(config: ClientConfiguration)  :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpointProvider = EndpointsProvider::getPaymentClientEndpoint,
-            authEndpointProvider = EndpointsProvider::getAuthEndpoint
+            endpointProvider = EndpointProvider::getPaymentClientEndpoint,
+            authEndpointProvider = EndpointProvider::getAuthEndpoint
         )
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
@@ -17,14 +17,14 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
 class SandboxClient(config: ClientConfiguration)  :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpointProvider = EndpointsProvider::getSandboxClientEndpoint,
-            authEndpointProvider = EndpointsProvider::getAuthEndpoint
+            endpointProvider = EndpointProvider::getSandboxClientEndpoint,
+            authEndpointProvider = EndpointProvider::getAuthEndpoint
         )
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
@@ -16,15 +16,16 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox
 
-import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
-class SandboxClient(config: ExpediaGroupClientConfiguration) :
-    GraphQLExecutor by BaseGraphQLClient
-        .Builder()
-        .key(config.key!!)
-        .secret(config.secret!!)
-        .endpoint("${config.endpoint!!}${if (config.endpoint.endsWith('/')) "" else "/"}supply/lodging-sandbox/graphql")
-        .authEndpoint(config.authEndpoint!!)
-        .build()
+class SandboxClient(config: ClientConfiguration)  :
+    GraphQLExecutor by BaseGraphQLClient(
+        config.toExpediaGroupClientConfiguration(
+            endpoint = EndpointsProvider.getSandboxClientEndpoint(config.environment ?: ClientEnvironment.PROD),
+            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+        )
+    )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/sandbox/SandboxClient.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
 import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
@@ -25,7 +24,7 @@ import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 class SandboxClient(config: ClientConfiguration)  :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpoint = EndpointsProvider.getSandboxClientEndpoint(config.environment ?: ClientEnvironment.PROD),
-            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+            endpointProvider = EndpointsProvider::getSandboxClientEndpoint,
+            authEndpointProvider = EndpointsProvider::getAuthEndpoint
         )
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
@@ -16,15 +16,16 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.graphql.supply
 
-import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
-class SupplyClient(config: ExpediaGroupClientConfiguration) :
-    GraphQLExecutor by BaseGraphQLClient
-        .Builder()
-        .key(config.key!!)
-        .secret(config.secret!!)
-        .endpoint("${config.endpoint!!}${if (config.endpoint.endsWith('/')) "" else "/"}supply/lodging/graphql")
-        .authEndpoint(config.authEndpoint!!)
-        .build()
+class SupplyClient(config: ClientConfiguration) :
+    GraphQLExecutor by BaseGraphQLClient(
+        config.toExpediaGroupClientConfiguration(
+            endpoint = EndpointsProvider.getSupplyClientEndpoint(config.environment ?: ClientEnvironment.PROD),
+            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+        )
+    )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
@@ -17,14 +17,14 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.supply
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
+import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 
 class SupplyClient(config: ClientConfiguration) :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpointProvider = EndpointsProvider::getSupplyClientEndpoint,
-            authEndpointProvider = EndpointsProvider::getAuthEndpoint
+            endpointProvider = EndpointProvider::getSupplyClientEndpoint,
+            authEndpointProvider = EndpointProvider::getAuthEndpoint
         )
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/supply/SupplyClient.kt
@@ -17,7 +17,6 @@
 package com.expediagroup.sdk.lodgingconnectivity.graphql.supply
 
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
-import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
 import com.expediagroup.sdk.lodgingconnectivity.configuration.EndpointsProvider
 import com.expediagroup.sdk.lodgingconnectivity.graphql.BaseGraphQLClient
 import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
@@ -25,7 +24,7 @@ import com.expediagroup.sdk.lodgingconnectivity.graphql.GraphQLExecutor
 class SupplyClient(config: ClientConfiguration) :
     GraphQLExecutor by BaseGraphQLClient(
         config.toExpediaGroupClientConfiguration(
-            endpoint = EndpointsProvider.getSupplyClientEndpoint(config.environment ?: ClientEnvironment.PROD),
-            authEndpoint = EndpointsProvider.getAuthEndpoint(config.environment ?: ClientEnvironment.PROD)
+            endpointProvider = EndpointsProvider::getSupplyClientEndpoint,
+            authEndpointProvider = EndpointsProvider::getAuthEndpoint
         )
     )

--- a/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/LodgingSupplySandboxClientUsageExample.java
+++ b/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/LodgingSupplySandboxClientUsageExample.java
@@ -16,7 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity;
 
-import com.expediagroup.sdk.core.configuration.ExpediaGroupClientConfiguration;
+import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration;
 import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.*;
 import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.*;
 
@@ -38,12 +38,10 @@ import java.util.List;
 public class LodgingSupplySandboxClientUsageExample {
 
     private static final SandboxClient client = new SandboxClient(
-            ExpediaGroupClientConfiguration
+            ClientConfiguration
                     .builder()
                     .key("KEY")
                     .secret("SECRET")
-                    .endpoint("https://test-api.sandbox.expediagroup.com")
-                    .authEndpoint("https://test-api.expediagroup.com/identity/oauth2/v3/token")
                     .build()
     );
 


### PR DESCRIPTION
## Summary
1. Cleaned up the workarounds we had in `ExpediaGroupClientConfiguration`.
2. Created a new classes related to the LC SDK configuration outside the core package.
3. Added a new `EndpointsProvider` class to handle different clients environments.

## New Configuration Interface
Changed the options the user can pass to the client and provided more comprehensive & strict way of controlling the endpoints and environments.

### What Has Changed?
1. Added a new configuration class special to LC clients called `ClientConfiguration`.
2. This new `ClientConfiguration` enables the user to specify the `environment` of the client instead of passing custom endpoint.
3. The `environment` param accepts `ClientEnvironment` enum, the SDK will handle the URLs mappings internally using the `EndpointsProvider` class.
4. The default environment is `ClientEnvironments.PROD`. 