### PR TITLE
fix: Convert Apollo Runtime Dependency to Gradle "api"

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:2.0.20"
     dokkaHtmlPlugin 'org.jetbrains.dokka:versioning-plugin:1.9.20'
 
-    implementation("com.apollographql.apollo:apollo-runtime:4.0.0")
+    api("com.apollographql.apollo:apollo-runtime:4.0.0")
     implementation("com.apollographql.adapters:apollo-adapters-core:0.0.4")
     implementation("com.apollographql.ktor:apollo-engine-ktor:0.0.2")
     implementation("org.slf4j:slf4j-simple:2.0.13")

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 artifactName=lodging-connectivity-sdk
 groupId=com.expediagroup
-version=0.0.2-SNAPSHOT
+version=0.0.3-SNAPSHOT
 description=SDK for Lodging Connectivity APIs

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
 artifactName=lodging-connectivity-sdk
 groupId=com.expediagroup
-version=0.0.1-SNAPSHOT
+version=0.0.2-SNAPSHOT
 description=SDK for Lodging Connectivity APIs


### PR DESCRIPTION
## Summary
We encountered an issue with the SDK where users needed to manually add the Apollo Kotlin Runtime as a dependency in order to use the SDK. This issue has been resolved in this PR by marking the Apollo Runtime dependency as `api()` instead of `implementation`.

Dependencies marked as `api` will be available to the consumer’s classpath, which - in our case - makes Apollo Kotlin available automatically.

>[!NOTE]
> Published new `0.0.3-SNAPSHOT` artifacts with these changes.