### PR TITLE
feat: add missing "IdSource" input for "property" queries

### DIFF
--- a/code/src/main/graphql/supply/operations/queries/DistrictByCoordinates.graphql
+++ b/code/src/main/graphql/supply/operations/queries/DistrictByCoordinates.graphql
@@ -1,4 +1,8 @@
-query DistrictByCoordinates($latitude: Float!, $longitude: Float!, $locale: String) {
+query DistrictByCoordinates(
+    $latitude: Float!,
+    $longitude: Float!,
+    $locale: String
+) {
     districtByCoordinates(latitude: $latitude, longitude: $longitude, locale: $locale) {
         id
         description

--- a/code/src/main/graphql/supply/operations/queries/MessageThread.graphql
+++ b/code/src/main/graphql/supply/operations/queries/MessageThread.graphql
@@ -1,7 +1,7 @@
 query MessageThread(
-    $messageThreadId: ID!,
-    $messagesLimit: Int,
-    $messagesCursor: String,
+    $id: ID!,
+    $pageSize: Int,
+    $cursor: String,
     $orderMessagesBy: MessageThreadMessagesOrderByInput
 ) {
     messageThread(id: $messageThreadId) {
@@ -33,7 +33,7 @@ query MessageThread(
             id
             petCount
         }
-        messages(limit: $messagesLimit, cursor: $messagesCursor, orderBy: $orderMessagesBy) {
+        messages(limit: $pageSize, cursor: $cursor, orderBy: $orderMessagesBy) {
             cursor
             totalCount
             elements {

--- a/code/src/main/graphql/supply/operations/queries/MessageThread.graphql
+++ b/code/src/main/graphql/supply/operations/queries/MessageThread.graphql
@@ -4,7 +4,7 @@ query MessageThread(
     $cursor: String,
     $orderMessagesBy: MessageThreadMessagesOrderByInput
 ) {
-    messageThread(id: $messageThreadId) {
+    messageThread(id: $id) {
         id
         creationDateTimeUtc
         bookingInquiry {

--- a/code/src/main/graphql/supply/operations/queries/PropertiesByAdvertiser.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertiesByAdvertiser.graphql
@@ -1,4 +1,9 @@
-query PropertiesByAdvertiser($id: ID!, $idSource: IdSource!, $pageSize: Int, $cursor: String) {
+query PropertiesByAdvertiser(
+    $id: ID!,
+    $idSource: IdSource! = EXPEDIA,
+    $pageSize: Int,
+    $cursor: String
+) {
     propertiesByAdvertiser(id: $id, idSource: $idSource, pageSize: $pageSize, cursor: $cursor) {
         cursor
         totalCount

--- a/code/src/main/graphql/supply/operations/queries/PropertyAggregatedReviews.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyAggregatedReviews.graphql
@@ -1,5 +1,9 @@
-query PropertyAggregatedReviews($propertyId: String!, $filters: AggregatedReviewsFiltersInput!) {
-    property(id: $propertyId) {
+query PropertyAggregatedReviews(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $filters: AggregatedReviewsFiltersInput!
+) {
+    property(id: $propertyId, idSource: $idSource) {
         aggregatedReviews(filters: $filters) {
             brandsWithScores {
                 brandName

--- a/code/src/main/graphql/supply/operations/queries/PropertyAmenities.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyAmenities.graphql
@@ -1,5 +1,9 @@
-query PropertyAmenities($propertyId: String!, $filters: AmenitiesFiltersInput) {
-    property(id: $propertyId) {
+query PropertyAmenities(
+    $propertyId: String!,
+    $idSource: IdSource,
+    $filters: AmenitiesFiltersInput
+) {
+    property(id: $propertyId, idSource: $idSource) {
         amenities(filters: $filters) {
             key
             value {

--- a/code/src/main/graphql/supply/operations/queries/PropertyAmenities.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyAmenities.graphql
@@ -1,6 +1,6 @@
 query PropertyAmenities(
     $propertyId: String!,
-    $idSource: IdSource,
+    $idSource: IdSource = EXPEDIA,
     $filters: AmenitiesFiltersInput
 ) {
     property(id: $propertyId, idSource: $idSource) {

--- a/code/src/main/graphql/supply/operations/queries/PropertyDistrict.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyDistrict.graphql
@@ -1,5 +1,9 @@
-query PropertyDistrict($propertyId: String!, $locale: String) {
-    property(id: $propertyId) {
+query PropertyDistrict(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $locale: String
+) {
+    property(id: $propertyId, idSource: $idSource) {
         district(locale: $locale) {
             description
             id

--- a/code/src/main/graphql/supply/operations/queries/PropertyFeeSets.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyFeeSets.graphql
@@ -1,5 +1,9 @@
-query PropertyFeeSets($propertyId: String!, $filters: PropertyFeeSetsFiltersInput!,) {
-    property(id: $propertyId) {
+query PropertyFeeSets(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $filters: PropertyFeeSetsFiltersInput!
+) {
+    property(id: $propertyId, idSource: $idSource) {
         feeSets(filters: $filters) {
             elements {
                 businessModel

--- a/code/src/main/graphql/supply/operations/queries/PropertyListing.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyListing.graphql
@@ -1,5 +1,9 @@
-query PropertyListings($propertyId: String!, $domains: [String!]!) {
-    property(id: $propertyId) {
+query PropertyListings(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $domains: [String!]!
+) {
+    property(id: $propertyId, idSource: $idSource) {
         listings(domains: $domains) {
             locale
             url

--- a/code/src/main/graphql/supply/operations/queries/PropertyMedia.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyMedia.graphql
@@ -1,5 +1,9 @@
-query PropertyMedia($propertyId: String!, $filters: ImagesFiltersInput) {
-    property(id: $propertyId) {
+query PropertyMedia(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $filters: ImagesFiltersInput
+) {
+    property(id: $propertyId, idSource: $idSource) {
         media {
             images(filters: $filters) {
                 elements {

--- a/code/src/main/graphql/supply/operations/queries/PropertyMessageThreads.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyMessageThreads.graphql
@@ -1,12 +1,13 @@
 query PropertyMessageThreads(
     $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
     $filters: PropertyMessageThreadsFiltersInput!,
     $orderBy: PropertyMessageThreadsOrderByInput
-    $limit: Int,
+    $pageSize: Int,
     $cursor: String,
 ) {
-    property(id: $propertyId) {
-        messageThreads(filters: $filters, limit: $limit, cursor: $cursor, orderBy: $orderBy) {
+    property(id: $propertyId, idSource: $idSource) {
+        messageThreads(filters: $filters, limit: $pageSize, cursor: $cursor, orderBy: $orderBy) {
             cursor
             totalCount
             elements {

--- a/code/src/main/graphql/supply/operations/queries/PropertyMessages.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyMessages.graphql
@@ -1,6 +1,12 @@
-query PropertyMessages($filters: PropertyMessagesFiltersInput!, $propertyId: String!, $cursor: String, $limit: Int) {
-    property(id: $propertyId) {
-        messages(filters: $filters, cursor: $cursor, limit: $limit) {
+query PropertyMessages(
+    $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
+    $cursor: String,
+    $pageSize: Int,
+    $filters: PropertyMessagesFiltersInput!
+) {
+    property(id: $propertyId, idSource: $idSource) {
+        messages(filters: $filters, cursor: $cursor, limit: $pageSize) {
             cursor
             totalCount
             elements {

--- a/code/src/main/graphql/supply/operations/queries/PropertyPromotions.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyPromotions.graphql
@@ -1,11 +1,12 @@
 query PropertyPromotions(
     $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
     $filter: FiltersInput
     $pageSize: Int!,
-    $after: String,
+    $cursor: String,
 ) {
-    property(id: $propertyId) {
-        promotions(pageSize: $pageSize, after: $after, filter: $filter) {
+    property(id: $propertyId, idSource: $idSource) {
+        promotions(pageSize: $pageSize, after: $cursor, filter: $filter) {
             totalCount
             pageInfo {
                 endCursor

--- a/code/src/main/graphql/supply/operations/queries/PropertyReservations.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyReservations.graphql
@@ -1,5 +1,6 @@
 query PropertyReservations(
     $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
     $pageSize: Int!,
     $cursor: String,
     $filter: ReservationFilterInput,
@@ -7,7 +8,7 @@ query PropertyReservations(
     $includePaymentInstrumentToken: Boolean! =  false,
     $includeSupplierAmount: Boolean! = false
 ) {
-    property(id: $propertyId) {
+    property(id: $propertyId, idSource: $idSource) {
         reservations(pageSize: $pageSize, checkOutDate: $checkOutDate, filter: $filter, after: $cursor) {
             totalCount
             pageInfo {

--- a/code/src/main/graphql/supply/operations/queries/PropertyReservationsSummary.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyReservationsSummary.graphql
@@ -1,11 +1,12 @@
 query PropertyReservationsSummary(
     $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
     $pageSize: Int!,
     $cursor: String,
     $filter: ReservationFilterInput,
     $checkOutDate: CheckOutDateFilter,
 ) {
-    property(id: $propertyId) {
+    property(id: $propertyId, idSource: $idSource) {
         reservations(pageSize: $pageSize, checkOutDate: $checkOutDate, filter: $filter, after: $cursor) {
             totalCount
             pageInfo {

--- a/code/src/main/graphql/supply/operations/queries/PropertyReviews.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyReviews.graphql
@@ -1,12 +1,13 @@
 query PropertyReviews(
     $propertyId: String!,
+    $idSource: IdSource = EXPEDIA,
     $orderBy: ReviewsOrderBy,
     $filter: ReviewFilter,
     $pageSize: Int!,
-    $after: String
+    $cursor: String
 ) {
-    property(id: $propertyId) {
-        reviews(pageSize: $pageSize, orderBy: $orderBy, filter: $filter, after: $after) {
+    property(id: $propertyId, idSource: $idSource) {
+        reviews(pageSize: $pageSize, orderBy: $orderBy, filter: $filter, after: $cursor) {
             cursor
             reviews {
                 body {

--- a/code/src/main/graphql/supply/operations/queries/PropertyUnits.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyUnits.graphql
@@ -1,6 +1,6 @@
 query PropertyUnits(
     $propertyID: String!,
-    $idSource: IdSource,
+    $idSource: IdSource = EXPEDIA,
     $includeRegistration: Boolean! = false
 ) {
     property(id: $propertyID, idSource: $idSource) {

--- a/code/src/main/graphql/supply/operations/queries/PropertyUnitsRegistration.graphql
+++ b/code/src/main/graphql/supply/operations/queries/PropertyUnitsRegistration.graphql
@@ -1,6 +1,6 @@
 query PropertyUnitRegistrations(
     $propertyID: String!,
-    $idSource: IdSource
+    $idSource: IdSource = EXPEDIA
 ) {
     property(id: $propertyID, idSource: $idSource) {
         id

--- a/code/src/main/graphql/supply/operations/queries/UndeliveredNotifications.graphql
+++ b/code/src/main/graphql/supply/operations/queries/UndeliveredNotifications.graphql
@@ -1,5 +1,5 @@
-query UndeliveredNotifications($filters: UndeliveredNotificationsFiltersInput!, $cursor: String, $limit: Int) {
-    undeliveredNotifications(filters: $filters, cursor: $cursor, limit: $limit) {
+query UndeliveredNotifications($filters: UndeliveredNotificationsFiltersInput!, $cursor: String, $pageSize: Int) {
+    undeliveredNotifications(filters: $filters, cursor: $cursor, limit: $pageSize) {
         cursor
         totalCount
         elements {


### PR DESCRIPTION
## Summary
1. Added missing optional `IdSource = EXPEDIA` input to all `property` sub-queries.
2. Unified the pagination controls for all queries. 
    - Cursor = `$cursor`
    - Page Size = `$pageSize`