### PR TITLE
chore: sync examples and docs with latest operations changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Make sure you have **Java 8** or higher.
 ```groovy
 // gradle.build
 dependencies {
-    implementation 'com.expediagroup:lodging-connectivity-sdk:1.0.2-SNAPSHOT'
+    implementation 'com.expediagroup:lodging-connectivity-sdk:1.0.3-SNAPSHOT'
 }
 ```
 
@@ -29,7 +29,7 @@ dependencies {
 <dependency>
     <groupId>com.expediagroup</groupId>
     <artifactId>lodging-connectivity-sdk</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/code/tasks-gradle/apollo.gradle
+++ b/code/tasks-gradle/apollo.gradle
@@ -2,7 +2,6 @@ apollo {
     service("supply") {
         generateKotlinModels.set(false)
         nullableFieldStyle.set("javaOptional")
-        generateOptionalOperationVariables.set(false)
 
         srcDir("src/main/graphql/supply")
 
@@ -34,7 +33,6 @@ apollo {
     service("payment") {
         generateKotlinModels.set(false)
         nullableFieldStyle.set("javaOptional")
-        generateOptionalOperationVariables.set(false)
 
         srcDir("src/main/graphql/payment")
 
@@ -49,7 +47,6 @@ apollo {
     service("sandbox") {
         generateKotlinModels.set(false)
         nullableFieldStyle.set("javaOptional")
-        generateOptionalOperationVariables.set(false)
 
         srcDir("src/main/graphql/sandbox")
 

--- a/docs/payment-client.md
+++ b/docs/payment-client.md
@@ -76,7 +76,7 @@ At the moment, there is only one query called `PaymentInstrument` you can execut
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/payment/operations/mutations/PaymentInstrument.query.graphql)
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/payment/queries/PaymentInstrument.graphql)
 - [Reference]()
 
 </details>

--- a/docs/sandbox-data-management-client.md
+++ b/docs/sandbox-data-management-client.md
@@ -76,14 +76,14 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 | Name               | Type               | Required            |
 |--------------------|--------------------|---------------------|
 | `cursor`           | `String`           | No                  |
-| `limit`            | `Int`              | No                  |
+| `pageSize`         | `Int`              | No                  |
 | `skipReservations` | `Boolean! = false` | No (defaults false) |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/queries/SandboxProperties.query.graphql) 
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/queries/SandboxProperties.graphql) 
 - [Reference]()
 
 </details>
@@ -102,15 +102,13 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 | Name                 | Type               | Required            |
 |----------------------|--------------------|---------------------|
 | `id`                 | `ID!`              | Yes                 |
-| `reservationsCursor` | `String`           | No                  |
-| `reservationsLimit`  | `Int`              | No                  |
 | `skipReservations`   | `Boolean! = false` | No (defaults false) |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/queries/SandboxProperty.query.graphql)
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/queries/SandboxProperty.graphql)
 - [Reference]()
 
 </details>
@@ -134,7 +132,7 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/queries/SandboxReservation.query.graphql) 
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/queries/SandboxReservation.graphql) 
 - [Reference]()
 
 </details>
@@ -158,15 +156,17 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `CancelReservationInput!` | Yes      |
+| Name               | Type      | Required |
+|--------------------|-----------|----------|
+| `id`               | `ID!`     | Yes      |
+| `sendNotification` | `Boolean` | No       |
+| `clientMutationId` | `String`  | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxCancelReservation.mutation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxCancelReservation.graphql)
 - [Reference]()
 
 </details>
@@ -182,15 +182,19 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                               | Required |
-|---------|------------------------------------|----------|
-| `input` | `ChangeReservationStayDatesInput!` | Yes      |
+| Name               | Type      | Required |
+|--------------------|-----------|----------|
+| `id`               | `ID!`     | Yes      |
+| `checkInDate`      | `Date!`   | Yes      |
+| `checkOutDate`     | `Date!`   | Yes      |
+| `sendNotification` | `Boolean` | No       |
+| `clientMutationId` | `String`  | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxChangeReservationStayDates.mutation.graphql) 
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxChangeReservationStayDates.graphql) 
 - [Reference]()
 
 </details>
@@ -206,15 +210,16 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                   | Required |
-|---------|------------------------|----------|
-| `input` | `CreatePropertyInput!` | Yes      |
+| Name               | Type     | Required |
+|--------------------|----------|----------|
+| `name`             | `String` | No       |
+| `clientMutationId` | `String` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxCreateProperty.mutation.graphql)  
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxCreateProperty.graphql)  
 - [Reference]()
 
 </details>
@@ -230,15 +235,34 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `CreateReservationInput!` | Yes      |
+| Name                     | Type                                     | Required |
+|--------------------------|------------------------------------------|----------|
+| `$propertyId`            | `ID!`                                    | Yes      |
+| `$checkInDate`           | `Date`                                   | No       |
+| `$checkOutDate`          | `Date`                                   | No       |
+| `$primaryGuest`          | `PrimaryGuestInput`                      | No       |
+| `$status`                | `ReservationStatusInput`                 | No       |
+| `$accessibilityText`     | `[String!]`                              | No       |
+| `$adultCount`            | `Int`                                    | No       |
+| `$bedTypes`              | `String`                                 | No       |
+| `$businessModel`         | `BusinessModelInput`                     | No       |
+| `$childAges`             | `[Int!]`                                 | No       |
+| `$childCount`            | `Int`                                    | No       |
+| `$clientMutationId`      | `String`                                 | No       |
+| `$multiRoomText`         | `String`                                 | No       |
+| `$paymentInstrumentType` | `PaymentInstrumentTypeInput`             | No       |
+| `$reconciliationType`    | `ReconciliationTypeInput`                | No       |
+| `$remittanceType`        | `RemittanceTypeInput`                    | No       |
+| `$sendNotification`      | `Boolean`                                | No       |
+| `$smokingType`           | `String`                                 | No       |
+| `$specialRequest`        | `String`                                 | No       |
+| `$valueAddedPromotions`  | `[ReservationValueAddedPromotionInput!]` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxCreateReservation.mutation.graphql) 
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxCreateReservation.graphql) 
 - [Reference]()
 
 </details>
@@ -254,15 +278,16 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                   | Required |
-|---------|------------------------|----------|
-| `input` | `DeletePropertyInput!` | Yes      |
+| Name               | Type     | Required |
+|--------------------|----------|----------|
+| `id`               | `ID!`    | Yes      |
+| `clientMutationId` | `String` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxDeleteProperty.mutation.graphql) 
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxDeleteProperty.graphql) 
 - [Reference]()
 
 </details>
@@ -278,15 +303,16 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                               | Required |
-|---------|------------------------------------|----------|
-| `input` | `DeletePropertyReservationsInput!` | Yes      |
+| Name               | Type     | Required |
+|--------------------|----------|----------|
+| `propertyId`       | `ID!`    | Yes      |
+| `clientMutationId` | `String` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxDeletePropertyReservations.mutation.graphql) 
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxDeletePropertyReservations.graphql) 
 - [Reference]()
 
 </details>
@@ -302,15 +328,16 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `DeleteReservationInput!` | Yes      |
+| Name               | Type     | Required |
+|--------------------|----------|----------|
+| `id`               | `ID!`    | Yes      |
+| `clientMutationId` | `String` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxDeleteReservation.mutation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxDeleteReservation.graphql)
 - [Reference]()
 
 </details>
@@ -326,15 +353,17 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                   | Required |
-|---------|------------------------|----------|
-| `input` | `UpdatePropertyInput!` | Yes      |
+| Name               | Type     | Required |
+|--------------------|----------|----------|
+| `id`               | `ID!`    | Yes      |
+| `name`             | `String` | No       |
+| `clientMutationId` | `String` | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxUpdateProperty.mutation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxUpdateProperty.graphql)
 - [Reference]()
 
 </details>
@@ -350,15 +379,24 @@ The SDK offers a set of queries & mutations you can execute using the `SandboxDa
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `UpdateReservationInput!` | Yes      |
+| Name               | Type                     | Required |
+|--------------------|--------------------------|----------|
+| `id`               | `ID!`                    | Yes      |
+| `checkInDate`      | `Date`                   | No       |
+| `checkOutDate`     | `Date`                   | No       |
+| `status`           | `ReservationStatusInput` | No       |
+| `adultCount`       | `Int`                    | No       |
+| `childCount`       | `Int`                    | No       |
+| `childAges`        | `[Int!]`                 | No       |
+| `sendNotification` | `Boolean`                | No       |
+| `specialRequest`   | `String`                 | No       |
+| `clientMutationId` | `String`                 | No       |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/operations/mutations/SandboxUpdateReservation.mutation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/sandbox/reservations/mutations/SandboxUpdateReservation.graphql)
 - [Reference]()
 
 </details>

--- a/docs/supply-client.md
+++ b/docs/supply-client.md
@@ -93,7 +93,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/reservations_query/) 
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/queries/PropertyReservations.graphql) 
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/queries/PropertyReservations.graphql) 
 - [Reference]()
 
 </details>
@@ -122,7 +122,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/reservations_query/)
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/queries/PropertyReservationsSummary.graphql)
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/queries/PropertyReservationsSummary.graphql)
 - [Reference]()
 
 </details>
@@ -158,7 +158,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/cancelReservation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/CancelReservation.graphql)
 - [Reference]()
 
 </details>
@@ -189,7 +189,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/cancelReservationReconciliation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelReservationReconciliation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/CancelReservationReconciliation.graphql)
 - [Reference]()
 
 </details>
@@ -221,7 +221,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelVrboReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/CancelVrboReservation.graphql)
 - [Reference]()
 
 </details>
@@ -253,7 +253,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/changeReservationReconciliation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/ChangeReservationReconciliation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/ChangeReservationReconciliation.graphql)
 - [Reference]()
 
 </details>
@@ -285,7 +285,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/ConfirmReservationNotification.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/ConfirmReservationNotification.graphql)
 - [Reference]()
 
 </details>
@@ -315,7 +315,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/RefundReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/reservations/mutations/RefundReservation.graphql)
 - [Reference]()
 
 </details>

--- a/docs/supply-client.md
+++ b/docs/supply-client.md
@@ -82,7 +82,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 |---------------------------------|--------------------------|-----------------------|
 | `propertyId`                    | `String!`                | Yes                   |
 | `idSource`                      | `IdSource`               | No (default: EXPEDIA) |
-| `pageSize`                      | `Int!`                   | Yes                   |
+| `pageSize`                      | `Int!`                   | No (default: 10)      |
 | `cursor`                        | `String`                 | No                    |
 | `filter`                        | `ReservationFilterInput` | No                    |
 | `checkOutDate`                  | `CheckOutDateFilter`     | No                    |
@@ -93,7 +93,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/reservations_query/) 
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/queries/PropertyReservations.graphql) 
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/queries/PropertyReservations.graphql) 
 - [Reference]()
 
 </details>
@@ -113,7 +113,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 |----------------|--------------------------|-----------------------|
 | `propertyId`   | `String!`                | Yes                   |
 | `idSource`     | `IdSource`               | No (default: EXPEDIA) |
-| `pageSize`     | `Int!`                   | Yes                   |
+| `pageSize`     | `Int!`                   | No (default: 10)      |
 | `cursor`       | `String`                 | No                    |
 | `filter`       | `ReservationFilterInput` | No                    |
 | `checkOutDate` | `CheckOutDateFilter`     | No                    |
@@ -122,7 +122,7 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/reservations_query/)
-- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/queries/PropertyReservationsSummary.graphql)
+- [Query Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/queries/PropertyReservationsSummary.graphql)
 - [Reference]()
 
 </details>
@@ -145,15 +145,20 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `CancelReservationInput!` | Yes      |
+| Name                            | Type                                   | Required            |
+|---------------------------------|----------------------------------------|---------------------|
+| `propertyId`                    | `ID!`                                  | Yes                 |
+| `reservationId`                 | `ID!`                                  | Yes                 |
+| `reason`                        | `ReservationPreStayCancellationReason` | No                  |
+| `skipReservation`               | `Boolean! = false`                     | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false`                     | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false`                     | No (default: false) |
 
 <br />
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/cancelReservation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/CancelReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelReservation.graphql)
 - [Reference]()
 
 </details>
@@ -169,15 +174,22 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                                    | Required |
-|---------|-----------------------------------------|----------|
-| `input` | `CancelReservationReconciliationInput!` | Yes      |
+| Name                            | Type                             | Required            |
+|---------------------------------|----------------------------------|---------------------|
+| `propertyId`                    | `ID!`                            | Yes                 |
+| `reservationId`                 | `ID!`                            | Yes                 |
+| `reason`                        | `ReservationCancellationReason!` | Yes                 |
+| `currencyCode`                  | `String`                         | No                  |
+| `penaltyAmount`                 | `Float`                          | No                  |
+| `skipReservation`               | `Boolean! = false`               | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false`               | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false`               | No (default: false) |
 
 <br />
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/cancelReservationReconciliation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/CancelReservationReconciliation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelReservationReconciliation.graphql)
 - [Reference]()
 
 </details>
@@ -193,15 +205,23 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                          | Required |
-|---------|-------------------------------|----------|
-| `input` | `CancelVrboReservationInput!` | Yes      |
+| Name                            | Type                              | Required            |
+|---------------------------------|-----------------------------------|---------------------|
+| `propertyId`                    | `ID!`                             | Yes                 |
+| `reservationId`                 | `ID!`                             | Yes                 |
+| `primaryReason`                 | `VrboCancellationReason!`         | Yes                 |
+| `secondaryReason`               | `VrboCancellationSecondaryReason` | No                  |
+| `clientMutationId`              | `String`                          | No                  |
+| `cancellationPolicyOverride`    | `VrboCancellationPolicyOverride`  | No                  |
+| `skipReservation`               | `Boolean! = false`                | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false`                | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false`                | No (default: false) |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/CancelVrboReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/CancelVrboReservation.graphql)
 - [Reference]()
 
 </details>
@@ -217,15 +237,23 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                                    | Required |
-|---------|-----------------------------------------|----------|
-| `input` | `ChangeReservationReconciliationInput!` | Yes      |
+| Name                            | Type                      | Required            |
+|---------------------------------|---------------------------|---------------------|
+| `propertyId`                    | `ID!`                     | Yes                 |
+| `reservationId`                 | `ID!`                     | Yes                 |
+| `checkInDate`                   | `LocalDate!`              | Yes                 |
+| `checkOutDate`                  | `LocalDate!`              | Yes                 |
+| `reason`                        | `ReservationChangeReason` | No                  |
+| `supplierAmount`                | `SupplierAmountInput`     | No                  |
+| `skipReservation`               | `Boolean! = false`        | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false`        | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false`        | No (default: false) |
 
 <br />
 
 **Resources**
 - [Documentation](https://developers.expediagroup.com/supply/lodging/docs/booking_apis/reservations/reference/changeReservationReconciliation/)
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/ChangeReservationReconciliation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/ChangeReservationReconciliation.graphql)
 - [Reference]()
 
 </details>
@@ -241,15 +269,23 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                                   | Required |
-|---------|----------------------------------------|----------|
-| `input` | `ConfirmReservationNotificationInput!` | Yes      |
+| Name                            | Type               | Required            |
+|---------------------------------|--------------------|---------------------|
+| `propertyId`                    | `ID!`              | Yes                 |
+| `reservationId`                 | `ID!`              | Yes                 |
+| `confirmationToken`             | `String!`          | Yes                 |
+| `actionType`                    | `String!`          | Yes                 |
+| `confirmationCode`              | `String!`          | Yes                 |
+| `clientMutationId`              | `String`           | No                  |
+| `skipReservation`               | `Boolean! = false` | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false` | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false` | No (default: false) |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment 
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/ConfirmReservationNotification.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/ConfirmReservationNotification.graphql)
 - [Reference]()
 
 </details>
@@ -265,15 +301,21 @@ The SDK offers a set of queries & mutations you can execute using the `SupplyCli
 
 **Operation Inputs:**
 
-| Name    | Type                      | Required |
-|---------|---------------------------|----------|
-| `input` | `RefundReservationInput!` | Yes      |
+| Name                            | Type                       | Required            |
+|---------------------------------|----------------------------|---------------------|
+| `propertyId`                    | `ID!`                      | Yes                 |
+| `reservationId`                 | `ID!`                      | Yes                 |
+| `reason`                        | `ReservationRefundReason!` | Yes                 |
+| `refund`                        | `MoneyInput!`              | Yes                 |
+| `skipReservation`               | `Boolean! = false`         | No (default: false) |
+| `includePaymentInstrumentToken` | `Boolean! = false`         | No (default: false) |
+| `includeSupplierAmount`         | `Boolean! = false`         | No (default: false) |
 
 <br />
 
 **Resources**
 - ⚠️ Documentation is unavailable at the moment
-- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/operations/mutations/RefundReservation.graphql)
+- [Mutation Definition](https://github.com/ExpediaGroup/lodging-connectivity-graphql-operations/blob/main/supply/mutations/RefundReservation.graphql)
 - [Reference]()
 
 </details>

--- a/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/SandboxDataManagementClientUsageExample.java
+++ b/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/SandboxDataManagementClientUsageExample.java
@@ -27,14 +27,7 @@ import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.SandboxDeleteRes
 import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.SandboxPropertiesQuery;
 import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.SandboxUpdatePropertyMutation;
 import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.SandboxUpdateReservationMutation;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.CancelReservationInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.ChangeReservationStayDatesInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.CreatePropertyInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.CreateReservationInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.DeletePropertyInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.DeleteReservationInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.UpdatePropertyInput;
-import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.type.UpdateReservationInput;
+import com.expediagroup.sdk.lodgingconnectivity.graphql.sandbox.fragment.SandboxReservationData;
 
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -70,9 +63,12 @@ public class SandboxDataManagementClientUsageExample {
         deletePropertyIfExists();
 
         //  ******* Create Property *******
-        CreatePropertyInput createPropertyInput = CreatePropertyInput.builder().name(Optional.of(PROPERTY_NAME)).build();
-        SandboxCreatePropertyMutation.Data createPropertyResponse = client.execute(new SandboxCreatePropertyMutation(createPropertyInput));
+        SandboxCreatePropertyMutation createProperty = SandboxCreatePropertyMutation
+                .builder()
+                .name(Optional.of(PROPERTY_NAME))
+                .build();
 
+        SandboxCreatePropertyMutation.Data createPropertyResponse = client.execute(createProperty);
 
         String propertyId = createPropertyResponse.createProperty.property.id;
 
@@ -81,81 +77,98 @@ public class SandboxDataManagementClientUsageExample {
 
 
         // ******* Update Property Name *******
-        UpdatePropertyInput updatePropertyInput = UpdatePropertyInput.builder().id(propertyId).name(Optional.of(UPDATED_PROPERTY_NAME)).build();
-        SandboxUpdatePropertyMutation.Data updatePropertyResponse = client.execute(new SandboxUpdatePropertyMutation(updatePropertyInput));
+        SandboxUpdatePropertyMutation updateProperty = SandboxUpdatePropertyMutation
+                .builder()
+                .id(propertyId)
+                .name(Optional.of(UPDATED_PROPERTY_NAME))
+                .build();
+
+        SandboxUpdatePropertyMutation.Data updatePropertyResponse = client.execute(updateProperty);
 
         System.out.println("Property Updated: " + propertyId);
         System.out.println(updatePropertyResponse);
 
 
         // ******* Create Reservation *******
-        CreateReservationInput createReservationInput = CreateReservationInput
+        SandboxCreateReservationMutation createReservation = SandboxCreateReservationMutation
                 .builder()
                 .propertyId(propertyId)
                 .childCount(Optional.of(4))
                 .adultCount(Optional.of(2))
                 .build();
 
-        SandboxCreateReservationMutation.Data createReservationResponse = client.execute(new SandboxCreateReservationMutation(createReservationInput));
+        SandboxCreateReservationMutation.Data createReservationResponse = client.execute(createReservation);
 
+        SandboxReservationData reservationData = createReservationResponse.createReservation.reservation.sandboxReservationData;
 
-        String reservationId = createReservationResponse.createReservation.reservation.sandboxReservationFragment.id;
-
-        System.out.println("Reservation Created: " + reservationId);
+        System.out.println("Reservation Created: " + reservationData.id);
         System.out.println(createReservationResponse);
 
 
         // ******* Update Reservation *******
-        UpdateReservationInput updateReservationInput = UpdateReservationInput
+        SandboxUpdateReservationMutation updateReservation = SandboxUpdateReservationMutation
                 .builder()
-                .id(reservationId)
+                .id(reservationData.id)
                 .childAges(Optional.of(Arrays.asList(3, 5, 7)))
                 .build();
 
-        SandboxUpdateReservationMutation.Data updateReservationResponse = client.execute(new SandboxUpdateReservationMutation(updateReservationInput));
+        SandboxUpdateReservationMutation.Data updateReservationResponse = client.execute(updateReservation);
 
-        System.out.println("Reservation Updated: " + reservationId);
+        reservationData = updateReservationResponse.updateReservation.reservation.sandboxReservationData;
+
+        System.out.println("Reservation Updated: " + reservationData.id);
         System.out.println(updateReservationResponse);
 
 
         // ******* Update Reservation Stay Dates *******
-        ChangeReservationStayDatesInput changeStayDatesInput = ChangeReservationStayDatesInput
+        SandboxChangeReservationStayDatesMutation changeReservationStayDates = SandboxChangeReservationStayDatesMutation
                 .builder()
-                .id(reservationId)
+                .id(reservationData.id)
                 .checkInDate(LocalDate.of(2024, 6, 5))
                 .checkOutDate(LocalDate.of(2024, 6, 10))
                 .build();
 
-        SandboxChangeReservationStayDatesMutation.Data changeStayDatesResponse = client.execute(new SandboxChangeReservationStayDatesMutation(changeStayDatesInput));
+        SandboxChangeReservationStayDatesMutation.Data changeStayDatesResponse = client.execute(changeReservationStayDates);
 
-        System.out.println("Reservation Stay Dates Updated: " + reservationId);
+        reservationData = changeStayDatesResponse.changeReservationStayDates.reservation.sandboxReservationData;
+
+        System.out.println("Reservation Stay Dates Updated: " + reservationData.id);
         System.out.println(changeStayDatesResponse);
 
-
         // ******* Cancel Reservation *******
-        CancelReservationInput cancelReservationInput = CancelReservationInput
+        SandboxCancelReservationMutation cancelReservation = SandboxCancelReservationMutation
                 .builder()
-                .id(reservationId)
+                .id(reservationData.id)
                 .sendNotification(Optional.of(false))
                 .build();
 
-        SandboxCancelReservationMutation.Data cancelReservationResponse = client.execute(new SandboxCancelReservationMutation(cancelReservationInput));
+        SandboxCancelReservationMutation.Data cancelReservationResponse = client.execute(cancelReservation);
 
-        System.out.println("Reservation Was Canceled: " + reservationId);
+        reservationData = cancelReservationResponse.cancelReservation.reservation.sandboxReservationData;
+
+        System.out.println("Reservation Was Canceled: " + reservationData.id);
         System.out.println(cancelReservationResponse);
 
 
         // ******* Delete Reservation *******
-        DeleteReservationInput deleteReservationInput = DeleteReservationInput.builder().id(reservationId).build();
-        SandboxDeleteReservationMutation.Data deleteReservationResponse = client.execute(new SandboxDeleteReservationMutation(deleteReservationInput));
+        SandboxDeleteReservationMutation deleteReservation = SandboxDeleteReservationMutation
+                .builder()
+                .id(reservationData.id)
+                .build();
 
-        System.out.println("Reservation Was Deleted: " + reservationId);
+        SandboxDeleteReservationMutation.Data deleteReservationResponse = client.execute(deleteReservation);
+
+        System.out.println("Reservation Was Deleted: " + reservationData.id);
         System.out.println(deleteReservationResponse);
 
 
         // ******* Delete Property *******
-        DeletePropertyInput deletePropertyInput = DeletePropertyInput.builder().id(propertyId).build();
-        SandboxDeletePropertyMutation.Data deletePropertyResponse = client.execute(new SandboxDeletePropertyMutation(deletePropertyInput));
+        SandboxDeletePropertyMutation deleteProperty = SandboxDeletePropertyMutation
+                .builder()
+                .id(propertyId)
+                .build();
+
+        SandboxDeletePropertyMutation.Data deletePropertyResponse = client.execute(deleteProperty);
 
         System.out.println("Property Was Deleted: " + propertyId);
         System.out.println(deletePropertyResponse);
@@ -170,8 +183,8 @@ public class SandboxDataManagementClientUsageExample {
         propertiesResponse.properties.elements.forEach(property -> {
             if (property.name.equals(PROPERTY_NAME) || property.name.equals(UPDATED_PROPERTY_NAME)) {
                 System.out.println("Deleting existing property: ID: " + property.id + ", Name: " + property.name);
-                DeletePropertyInput deletePropertyInput = DeletePropertyInput.builder().id(property.id).build();
-                client.execute(new SandboxDeletePropertyMutation(deletePropertyInput));
+                SandboxDeletePropertyMutation deleteProperty = SandboxDeletePropertyMutation.builder().id(property.id).build();
+                client.execute(deleteProperty);
             }
         });
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 groupId=com.expediagroup
-version=1.0.2-SNAPSHOT
+version=1.0.3-SNAPSHOT
 artifactName=lodging-connectivity-sdk
 description=SDK for Lodging Connectivity APIs
 


### PR DESCRIPTION
## Summary
1. Updated the examples and docs to reflect the latest changes in the GraphQL operations definitions.
2. Updated the operations definitions links in the documentation.
3. Removed `generateOptionalOperationVariables.set(false)` from Apollo's plugin configuration. This allows all optional operation input variables to be wrapped with `Optional`.