### PR TITLE
chore: add PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 <!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
 
 # Notes
-<!-- Add any additional context or information. This could include things like links to documentation, follow-up tasks, edge cases considered, or potential risks. Any relevant thoughts or clarifications can go here. -->
+<!-- Add any additional context or information. This could include things like links to documentation, related issues, related PRs, follow-up tasks, edge cases considered, or potential risks. Any relevant thoughts or clarifications can go here. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@
 # Action
 <!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
 
+# Testing
+<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
+
 # Results
 <!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Situation
+<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
+
+# Task
+<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
+
+# Action
+<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
+
+# Results
+<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
+
+# Notes
+<!-- Add any additional context or information. This could include things like links to documentation, follow-up tasks, edge cases considered, or potential risks. Any relevant thoughts or clarifications can go here. -->


### PR DESCRIPTION
# Situation
The team realized that some changes being merged were more difficult to understand than they should be because they lacked the context and background given by the PR description. 

# Task
By creating a template, we think it will be more obvious that this is a necessary step for contributors.

# Action
Created a `PULL_REQUEST_TEMPLATE.md`.

# Testing
n/a

# Results
Success can be measured by looking at the increase in the number of merged pull requests with a filled out description into the repository going forward.

# Notes
Information about what pull request templates are: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates