### PR TITLE
chore: set custom user agent and namespace

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -57,31 +57,9 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api:2.0.2'
 }
 
+apply from: "tasks-gradle/generateProperties.gradle"
 apply from: "tasks-gradle/apollo.gradle"
 apply from: "tasks-gradle/publishing.gradle"
 apply from: "tasks-gradle/dokka.gradle"
 
-// Task to generate sdk.properties file in resources directory
-tasks.register('generateSdkProperties') {
-    def resourcesDir = "$projectDir/src/main/resources"
-    def propertiesFile = file("$resourcesDir/sdk.properties")
 
-    doLast {
-        if (!file(resourcesDir).exists()) {
-            file(resourcesDir).mkdirs()
-        }
-
-        propertiesFile.withWriter('UTF-8') { writer ->
-            writer.writeLine("version=${version}")
-            writer.writeLine("artifactId=${rootProject.name}")
-            writer.writeLine("userAgentPrefix=expediagroup-sdk-java" +
-                    "-${rootProject.name.replaceFirst("-sdk", "")}")
-        }
-
-        println "Generated sdk.properties in $resourcesDir"
-    }
-}
-
-// Ensure generateSdkProperties runs before compilation
-compileKotlin.dependsOn generateSdkProperties
-compileJava.dependsOn generateSdkProperties

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -61,4 +61,27 @@ apply from: "tasks-gradle/apollo.gradle"
 apply from: "tasks-gradle/publishing.gradle"
 apply from: "tasks-gradle/dokka.gradle"
 
+// Task to generate sdk.properties file in resources directory
+tasks.register('generateSdkProperties') {
+    def resourcesDir = "$projectDir/src/main/resources"
+    def propertiesFile = file("$resourcesDir/sdk.properties")
 
+    doLast {
+        if (!file(resourcesDir).exists()) {
+            file(resourcesDir).mkdirs()
+        }
+
+        propertiesFile.withWriter('UTF-8') { writer ->
+            writer.writeLine("version=${version}")
+            writer.writeLine("artifactId=${rootProject.name}")
+            writer.writeLine("userAgentPrefix=expediagroup-sdk-java" +
+                    "-${rootProject.name.replaceFirst("-sdk", "")}")
+        }
+
+        println "Generated sdk.properties in $resourcesDir"
+    }
+}
+
+// Ensure generateSdkProperties runs before compilation
+compileKotlin.dependsOn generateSdkProperties
+compileJava.dependsOn generateSdkProperties

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
@@ -1,11 +1,15 @@
 package com.expediagroup.sdk.v2.core.client
 
+import com.expediagroup.sdk.v2.core.configuration.SdkMetadata
 import com.expediagroup.sdk.v2.core.request.initializer.ApiClientRequestInitializer
 import com.google.api.client.googleapis.services.AbstractGoogleClient
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.HttpTransport
 import com.google.api.client.json.JsonFactory
+import com.google.common.io.Resources
+import java.io.FileInputStream
+import java.util.*
 
 
 /**
@@ -26,7 +30,6 @@ class ApiClientBuilder(
     rootUrl: GenericUrl,
     requestInitializer: HttpRequestInitializer? = null,
     servicePath: String = "",
-    namespace: String,
 ) : AbstractGoogleClient.Builder(
     transport,
     rootUrl.build(),
@@ -44,7 +47,7 @@ class ApiClientBuilder(
     }
 
     init {
-        applicationName = namespace
+        applicationName = SdkMetadata.getArtifactId()
         googleClientRequestInitializer = ApiClientRequestInitializer.default()
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
@@ -7,10 +7,6 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.HttpTransport
 import com.google.api.client.json.JsonFactory
-import com.google.common.io.Resources
-import java.io.FileInputStream
-import java.util.*
-
 
 /**
  * Builder for constructing an instance of `ApiClient`. This class extends
@@ -22,7 +18,6 @@ import java.util.*
  * @param rootUrl The root URL for the API service.
  * @param requestInitializer Optional request initializer for HTTP requests.
  * @param servicePath The path to the service endpoint.
- * @param namespace The namespace for the API client, also used as the application name.
  */
 class ApiClientBuilder(
     transport: HttpTransport,

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/ApiClientBuilder.kt
@@ -1,6 +1,6 @@
 package com.expediagroup.sdk.v2.core.client
 
-import com.expediagroup.sdk.v2.core.request.extended.DefaultApiClientRequestInitializer
+import com.expediagroup.sdk.v2.core.request.initializer.ApiClientRequestInitializer
 import com.google.api.client.googleapis.services.AbstractGoogleClient
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequestInitializer
@@ -45,6 +45,6 @@ class ApiClientBuilder(
 
     init {
         applicationName = namespace
-        googleClientRequestInitializer = DefaultApiClientRequestInitializer.default()
+        googleClientRequestInitializer = ApiClientRequestInitializer.default()
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/SdkClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/SdkClient.kt
@@ -12,15 +12,12 @@ import java.io.InputStream
 /**
  * SdkClient is a wrapper for creating and executing API requests.
  *
- * @param namespace The namespace to be used for creating the API client.
  * @param configuration The client configuration implementing `FullClientConfiguration`.
  */
 class SdkClient(
-    namespace: String,
     configuration: FullClientConfiguration,
 ) {
     val apiClient: ApiClient = createApiClient(
-        namespace = namespace,
         configuration = configuration,
     )
 

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/util/ApiClientUtil.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/util/ApiClientUtil.kt
@@ -20,7 +20,6 @@ import com.google.api.client.http.HttpTransport
  */
 @JvmOverloads
 fun createApiClient(
-    namespace: String,
     configuration: ClientConfiguration,
     transport: HttpTransport? = null
 ): ApiClient {
@@ -31,7 +30,6 @@ fun createApiClient(
         .add(getHttpCredentialsAdapter(configuration))
 
     val builder = ApiClientBuilder(
-        namespace = namespace,
         transport = transport ?: getSingletonApacheHttpTransport(configuration),
         jsonFactory = jsonFactory,
         rootUrl = GenericUrl((configuration as EndpointTrait).getEndpoint()),

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/configuration/SdkMetadata.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/configuration/SdkMetadata.kt
@@ -1,0 +1,42 @@
+package com.expediagroup.sdk.v2.core.configuration
+
+import com.expediagroup.sdk.v2.core.model.exception.client.ExpediaGroupConfigurationException
+import java.io.FileInputStream
+import java.io.IOException
+import java.util.Properties
+
+
+/**
+ * Singleton object that holds metadata information about the SDK.
+ *
+ * This metadata is loaded from the `gradle.properties` file and includes:
+ * - `artifactId`: The artifact ID of the SDK.
+ * - `version`: The version of the SDK.
+ * - `groupId`: The group ID of the SDK.
+ * - `description`: A brief description of the SDK.
+ *
+ * If the metadata cannot be loaded due to an `IOException`, an `ExpediaGroupConfigurationException` is thrown.
+ */
+internal data object SdkMetadata {
+    val artifactId: String
+    val version: String
+    val groupId: String
+    val description: String
+
+    init {
+        try {
+            Properties().apply {
+                FileInputStream("gradle.properties").use {
+                    load(it)
+                }
+            }.also { props ->
+                artifactId = props.getProperty("artifactName")
+                version = props.getProperty("version")
+                groupId = props.getProperty("groupId")
+                description = props.getProperty("description")
+            }
+        } catch (ioException: IOException) {
+            throw ExpediaGroupConfigurationException("Unable to load SDK metadata", ioException)
+        }
+    }
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/configuration/SdkMetadata.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/configuration/SdkMetadata.kt
@@ -1,42 +1,27 @@
 package com.expediagroup.sdk.v2.core.configuration
 
-import com.expediagroup.sdk.v2.core.model.exception.client.ExpediaGroupConfigurationException
+import com.google.common.io.Resources
 import java.io.FileInputStream
-import java.io.IOException
 import java.util.Properties
 
+internal object SdkMetadata {
+    private lateinit var artifactId: String
+    private lateinit var version: String
+    private lateinit var userAgentPrefix: String
 
-/**
- * Singleton object that holds metadata information about the SDK.
- *
- * This metadata is loaded from the `gradle.properties` file and includes:
- * - `artifactId`: The artifact ID of the SDK.
- * - `version`: The version of the SDK.
- * - `groupId`: The group ID of the SDK.
- * - `description`: A brief description of the SDK.
- *
- * If the metadata cannot be loaded due to an `IOException`, an `ExpediaGroupConfigurationException` is thrown.
- */
-internal data object SdkMetadata {
-    val artifactId: String
-    val version: String
-    val groupId: String
-    val description: String
+    fun getArtifactId(): String = artifactId
+    fun getVersion(): String = version
+    fun getUserAgentPrefix(): String = userAgentPrefix
 
     init {
-        try {
+        Resources.getResource("sdk.properties").file?.let { path ->
             Properties().apply {
-                FileInputStream("gradle.properties").use {
-                    load(it)
-                }
-            }.also { props ->
-                artifactId = props.getProperty("artifactName")
-                version = props.getProperty("version")
-                groupId = props.getProperty("groupId")
-                description = props.getProperty("description")
+                load(FileInputStream(path))
+            }.also { properties ->
+                artifactId = properties.getProperty("artifactId")
+                version = properties.getProperty("version")
+                userAgentPrefix = properties.getProperty("userAgentPrefix")
             }
-        } catch (ioException: IOException) {
-            throw ExpediaGroupConfigurationException("Unable to load SDK metadata", ioException)
         }
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
@@ -1,8 +1,6 @@
 package com.expediagroup.sdk.v2.core.model
 
-import com.google.common.io.Resources
-import java.io.FileInputStream
-import java.util.Properties
+import com.expediagroup.sdk.v2.core.configuration.SdkMetadata
 
 /**
  * Data class representing a user agent which contains information about the Java Development Kit (JDK) version,
@@ -15,17 +13,7 @@ data class UserAgent(
     val jdkVersion: String,
     val operatingSystem: String,
 ) {
-    private lateinit var userAgentPrefix: String
-
-    init {
-        Resources.getResource("sdk.properties").file?.let { path ->
-            Properties().apply {
-                load(FileInputStream(path))
-            }.also { properties ->
-                userAgentPrefix = properties.getProperty("userAgentPrefix")
-            }
-        }
-    }
+    private val userAgentPrefix: String = SdkMetadata.getUserAgentPrefix()
 
     override fun toString(): String =
         "$userAgentPrefix ($jdkVersion; $operatingSystem)"

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
@@ -1,0 +1,37 @@
+package com.expediagroup.sdk.v2.core.model
+
+import com.expediagroup.sdk.v2.core.configuration.SdkMetadata
+
+/**
+ * Data class representing a user agent which contains information about the Java Development Kit (JDK) version,
+ * operating system, SDK namespace, and SDK version.
+ *
+ * @param jdkVersion the version of the Java Development Kit (JDK) being used.
+ * @param operatingSystem the operating system on which the application is running.
+ * @param sdkNamespace the namespace of the SDK being used.
+ * @param sdkVersion the version of the SDK being used.
+ */
+data class UserAgent(
+    val jdkVersion: String,
+    val operatingSystem: String,
+    val sdkNamespace: String,
+    val sdkVersion: String,
+) {
+    constructor(
+        jdkVersion: String,
+        operatingSystem: String,
+    ) : this(
+        jdkVersion,
+        operatingSystem,
+        SdkMetadata.artifactId.removeSuffix("-sdk"),
+        SdkMetadata.version
+    )
+
+    /**
+     * Returns a string representation of the user agent.
+     *
+     * @return a formatted string containing the SDK namespace and version, along with the JDK version and operating system.
+     */
+    override fun toString(): String =
+        "expediagroup-sdk-java-$sdkNamespace/$sdkVersion ($jdkVersion; $operatingSystem)"
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/model/UserAgent.kt
@@ -1,6 +1,8 @@
 package com.expediagroup.sdk.v2.core.model
 
-import com.expediagroup.sdk.v2.core.configuration.SdkMetadata
+import com.google.common.io.Resources
+import java.io.FileInputStream
+import java.util.Properties
 
 /**
  * Data class representing a user agent which contains information about the Java Development Kit (JDK) version,
@@ -8,30 +10,23 @@ import com.expediagroup.sdk.v2.core.configuration.SdkMetadata
  *
  * @param jdkVersion the version of the Java Development Kit (JDK) being used.
  * @param operatingSystem the operating system on which the application is running.
- * @param sdkNamespace the namespace of the SDK being used.
- * @param sdkVersion the version of the SDK being used.
  */
 data class UserAgent(
     val jdkVersion: String,
     val operatingSystem: String,
-    val sdkNamespace: String,
-    val sdkVersion: String,
 ) {
-    constructor(
-        jdkVersion: String,
-        operatingSystem: String,
-    ) : this(
-        jdkVersion,
-        operatingSystem,
-        SdkMetadata.artifactId.removeSuffix("-sdk"),
-        SdkMetadata.version
-    )
+    private lateinit var userAgentPrefix: String
 
-    /**
-     * Returns a string representation of the user agent.
-     *
-     * @return a formatted string containing the SDK namespace and version, along with the JDK version and operating system.
-     */
+    init {
+        Resources.getResource("sdk.properties").file?.let { path ->
+            Properties().apply {
+                load(FileInputStream(path))
+            }.also { properties ->
+                userAgentPrefix = properties.getProperty("userAgentPrefix")
+            }
+        }
+    }
+
     override fun toString(): String =
-        "expediagroup-sdk-java-$sdkNamespace/$sdkVersion ($jdkVersion; $operatingSystem)"
+        "$userAgentPrefix ($jdkVersion; $operatingSystem)"
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/request/initializer/ApiClientRequestInitializer.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/request/initializer/ApiClientRequestInitializer.kt
@@ -1,5 +1,6 @@
-package com.expediagroup.sdk.v2.core.request.extended
+package com.expediagroup.sdk.v2.core.request.initializer
 
+import com.expediagroup.sdk.v2.core.model.UserAgent
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
 import com.google.api.client.googleapis.services.CommonGoogleClientRequestInitializer
 
@@ -13,7 +14,7 @@ import com.google.api.client.googleapis.services.CommonGoogleClientRequestInitia
  *
  * @param builder The builder used to construct the `DefaultApiClientRequestInitializer` instance.
  */
-class DefaultApiClientRequestInitializer(
+class ApiClientRequestInitializer(
     builder: Builder
 ) : CommonGoogleClientRequestInitializer(builder) {
     companion object {
@@ -27,9 +28,9 @@ class DefaultApiClientRequestInitializer(
          * @return A default instance of `DefaultApiClientRequestInitializer` configured with the default builder settings.
          */
         @JvmStatic
-        fun default(): DefaultApiClientRequestInitializer {
+        fun default(): ApiClientRequestInitializer {
             val builder = Builder()
-            return DefaultApiClientRequestInitializer(builder)
+            return ApiClientRequestInitializer(builder)
         }
 
         /**
@@ -39,8 +40,8 @@ class DefaultApiClientRequestInitializer(
          * to return a `DefaultApiClientRequestInitializer` with the current builder instance as a parameter.
          */
         class Builder : CommonGoogleClientRequestInitializer.Builder() {
-            override fun build(): DefaultApiClientRequestInitializer {
-                return DefaultApiClientRequestInitializer(this)
+            override fun build(): ApiClientRequestInitializer {
+                return ApiClientRequestInitializer(this)
             }
         }
     }
@@ -52,5 +53,21 @@ class DefaultApiClientRequestInitializer(
      */
     override fun initialize(request: AbstractGoogleClientRequest<*>) {
         super.initialize(request)
+        overrideUserAgent(request)
+    }
+
+    /**
+     * Overrides the user agent in the provided Google client request with a custom user agent string.
+     *
+     * @param request The Google client request whose user agent will be overridden.
+     */
+    private fun overrideUserAgent(request: AbstractGoogleClientRequest<*>) {
+        val (jdk, _, os) = request.requestHeaders.getFirstHeaderStringValue("x-goog-api-client")
+            .split(" ")
+
+        request.requestHeaders.userAgent = UserAgent(
+            jdkVersion = jdk,
+            operatingSystem = os
+        ).toString()
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -16,7 +16,7 @@ class FileManagementClient(
     configuration: ClientConfiguration
 ) {
     private val client = SdkClient(
-        namespace = "lodging-connectivity-file-management-client",
+        namespace = "lodging-connectivity-sdk",
         configuration = configuration.toFullClientConfiguration(
             endpointProvider = EndpointProvider::getFileManagementClientEndpoint,
             authEndpointProvider = EndpointProvider::getAuthEndpoint

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/filemanagement/client/FileManagementClient.kt
@@ -16,7 +16,6 @@ class FileManagementClient(
     configuration: ClientConfiguration
 ) {
     private val client = SdkClient(
-        namespace = "lodging-connectivity-sdk",
         configuration = configuration.toFullClientConfiguration(
             endpointProvider = EndpointProvider::getFileManagementClientEndpoint,
             authEndpointProvider = EndpointProvider::getAuthEndpoint

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/BaseGraphQLClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/BaseGraphQLClient.kt
@@ -27,10 +27,9 @@ import com.expediagroup.sdk.v2.core.client.util.createApiClient
 import com.expediagroup.sdk.v2.lodgingconnectivity.configuration.ClientConfiguration
 import java.util.concurrent.CompletableFuture
 
-class BaseGraphQLClient(configuration: FullClientConfiguration, namespace: String) : GraphQLExecutor {
+class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecutor {
     private val engine: ApiClientApolloHttpEngine = ApiClientApolloHttpEngine(
         createApiClient(
-            namespace = namespace,
             configuration = configuration
         )
     )
@@ -47,7 +46,7 @@ class BaseGraphQLClient(configuration: FullClientConfiguration, namespace: Strin
 
     class Builder(private val namespace: String) : DefaultClientBuilder<BaseGraphQLClient>() {
         override fun build(): BaseGraphQLClient {
-            return BaseGraphQLClient(this.buildConfiguration(), namespace)
+            return BaseGraphQLClient(this.buildConfiguration())
         }
     }
 

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/payment/PaymentClient.kt
@@ -48,5 +48,5 @@ class PaymentClient(config: ClientConfiguration):
             endpointProvider = EndpointProvider::getPaymentClientEndpoint,
             authEndpointProvider = EndpointProvider::getAuthEndpoint
         ),
-        "lodging-connectivity-payment-client"
+        namespace = "lodging-connectivity-sdk"
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/payment/PaymentClient.kt
@@ -48,5 +48,4 @@ class PaymentClient(config: ClientConfiguration):
             endpointProvider = EndpointProvider::getPaymentClientEndpoint,
             authEndpointProvider = EndpointProvider::getAuthEndpoint
         ),
-        namespace = "lodging-connectivity-sdk"
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/sandbox/SandboxDataManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/sandbox/SandboxDataManagementClient.kt
@@ -50,5 +50,4 @@ class SandboxDataManagementClient(config: ClientConfiguration) :
             authEndpointProvider = EndpointProvider::getAuthEndpoint,
             defaultEnvironment = ClientEnvironment.SANDBOX_PROD
         ),
-        namespace = "lodging-connectivity-sdk"
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/sandbox/SandboxDataManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/sandbox/SandboxDataManagementClient.kt
@@ -50,5 +50,5 @@ class SandboxDataManagementClient(config: ClientConfiguration) :
             authEndpointProvider = EndpointProvider::getAuthEndpoint,
             defaultEnvironment = ClientEnvironment.SANDBOX_PROD
         ),
-        namespace = "lodging-connectivity-sandbox-client"
+        namespace = "lodging-connectivity-sdk"
     )

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/supply/SupplyClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/supply/SupplyClient.kt
@@ -52,5 +52,5 @@ class SupplyClient(config: ClientConfiguration) :
            endpointProvider = EndpointProvider::getSupplyClientEndpoint,
            authEndpointProvider = EndpointProvider::getAuthEndpoint
        ),
-       namespace = "lodging-connectivity-supply-client"
+       namespace = "lodging-connectivity-sdk"
    )

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/supply/SupplyClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/supply/SupplyClient.kt
@@ -52,5 +52,4 @@ class SupplyClient(config: ClientConfiguration) :
            endpointProvider = EndpointProvider::getSupplyClientEndpoint,
            authEndpointProvider = EndpointProvider::getAuthEndpoint
        ),
-       namespace = "lodging-connectivity-sdk"
    )

--- a/code/tasks-gradle/generateProperties.gradle
+++ b/code/tasks-gradle/generateProperties.gradle
@@ -1,0 +1,24 @@
+// Task to generate sdk.properties file in resources directory
+tasks.register('generateSdkProperties') {
+    def resourcesDir = "$projectDir/src/main/resources"
+    def propertiesFile = file("$resourcesDir/sdk.properties")
+
+    doLast {
+        if (!file(resourcesDir).exists()) {
+            file(resourcesDir).mkdirs()
+        }
+
+        propertiesFile.withWriter('UTF-8') { writer ->
+            writer.writeLine("version=${version}")
+            writer.writeLine("artifactId=${rootProject.name}")
+            writer.writeLine("userAgentPrefix=expediagroup-sdk-java" +
+                    "-${rootProject.name.replaceFirst("-sdk", "")}")
+        }
+
+        println "Generated sdk.properties in $resourcesDir"
+    }
+}
+
+// Ensure generateSdkProperties runs before compilation
+compileKotlin.dependsOn generateSdkProperties
+compileJava.dependsOn generateSdkProperties


### PR DESCRIPTION
# Situation
* User agents are automatically set by the Google API client. The default value generated by the client does not follow our format for the user agent header, which is used in our metrics collection.

# Task
Update the user agent format to follow our custom SDK format.

# Action
Updated the user agent header value.

# Testing
**TBA**

# Results
User agent now follows our conventions.

# Notes
## The Why
* Why set the user agent value in a subclass of the `CommonGoogleClientRequestInitializer` and not the usual `HttpRequestInitializer`?

The user agent value was done in the `ApiClientRequestInitializer` class, which is a subclass of `CommonGoogleClientRequestInitializer`. The `CommonGoogleClientRequestInitializer` is a higher layer compared to the `HttpRequestInitializer`. 

The `CommonGoogleClientRequestInitializer.initialize()` super method handles some internal request configurations, including automatically adding some headers for us (e.g. `user-agent`). Also, the initializer handles executing the initialize method in sub `HttpRequestInitializer` instances.

* Why rename `namespace` value in all clients?

We want to insure a consistent namespace for each client. The namespace is an SDK value, in other words, a client agnostic value that should not be coupled with each client.