### PR TITLE
fix: remove simple logger from core dependencies

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation 'com.apollographql.ktor:apollo-engine-ktor:0.0.2'
 
     /* EG SDK Core */
-    implementation 'org.slf4j:slf4j-simple:2.0.16'
     implementation 'io.ktor:ktor-client-core:2.3.12'
     implementation 'io.ktor:ktor-client-auth-jvm:2.3.12'
     implementation 'io.ktor:ktor-http:2.3.12'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation 'org.slf4j:slf4j-simple:2.0.16'
     implementation(project(":code"))
 }
 


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
Noticed that a concrete SLF4J implementation `org.slf4j:slf4j-simple` was added to the core dependencies. However, the SDK core should accept any SLF4J implementation provided by the host app.

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
Remove the extra dependency `org.slf4j:slf4j-simple`

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
Removed `org.slf4j:slf4j-simple` dependency and added it to the example module dependencies. 

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Manually tested

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
The SDK core now is not dependant on any SLF4J implementation, SDK users can use any implementation.

# Notes
<!-- Add any additional context or information. This could include things like links to documentation, related issues, related PRs, follow-up tasks, edge cases considered, or potential risks. Any relevant thoughts or clarifications can go here. -->
None