### PR TITLE
feat: graphql executor sync and async execute method

### DIFF
--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/util/ApiClientUtil.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/core/client/util/ApiClientUtil.kt
@@ -11,9 +11,8 @@ import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpTransport
 
 /**
- * Creates an instance of `ApiClient` using the provided namespace, client configuration, and optional HTTP transport.
+ * Creates an instance of `ApiClient` using the provided client configuration, and optional HTTP transport.
  *
- * @param namespace The namespace to be used for creating the API client.
  * @param configuration The client configuration implementing `ClientConfiguration` interface. Must also implement `EndpointTrait`.
  * @param transport An optional `HttpTransport` object. If not provided, a default transport will be used.
  * @return An instance of `ApiClient`.

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/BaseGraphQLClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/BaseGraphQLClient.kt
@@ -44,7 +44,7 @@ class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecuto
         .httpEngine(engine)
         .build()
 
-    class Builder(private val namespace: String) : DefaultClientBuilder<BaseGraphQLClient>() {
+    class Builder() : DefaultClientBuilder<BaseGraphQLClient>() {
         override fun build(): BaseGraphQLClient {
             return BaseGraphQLClient(this.buildConfiguration())
         }
@@ -57,7 +57,7 @@ class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecuto
      * @return The result of the query execution, with errors handled.
      * @throws ExpediaGroupServiceException If the query execution returns errors.
      */
-    override fun <T : Query.Data> execute(query: Query<T>): CompletableFuture<T> {
+    override fun <T : Query.Data> executeAsync(query: Query<T>): CompletableFuture<T> {
         val promise: CompletableFuture<T> = CompletableFuture()
 
         apolloClient.query(query).enqueue { response ->
@@ -81,6 +81,9 @@ class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecuto
         return promise
     }
 
+    override fun <T : Query.Data> execute(query: Query<T>): T =
+        executeAsync(query).get()
+
 
     /**
      * Executes a GraphQL mutation and returns the result.
@@ -89,7 +92,7 @@ class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecuto
      * @return The result of the mutation execution, with errors handled.
      * @throws ExpediaGroupServiceException If the mutation execution returns errors.
      */
-    override fun <T : Mutation.Data> execute(mutation: Mutation<T>): CompletableFuture<T> {
+    override fun <T : Mutation.Data> executeAsync(mutation: Mutation<T>): CompletableFuture<T> {
         val promise: CompletableFuture<T> = CompletableFuture()
 
         apolloClient.mutation(mutation).enqueue { response ->
@@ -112,4 +115,7 @@ class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecuto
 
         return promise
     }
+
+    override fun <T : Mutation.Data> execute(mutation: Mutation<T>): T =
+        executeAsync(mutation).get()
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/GraphQLExecutor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/v2/lodgingconnectivity/graphql/GraphQLExecutor.kt
@@ -21,6 +21,8 @@ import com.apollographql.apollo.api.Query
 import java.util.concurrent.CompletableFuture
 
 interface GraphQLExecutor {
-    fun <T : Query.Data> execute(query: Query<T>): CompletableFuture<T>
-    fun <T : Mutation.Data> execute(mutation: Mutation<T>): CompletableFuture<T>
+    fun <T : Query.Data> executeAsync(query: Query<T>): CompletableFuture<T>
+    fun <T : Mutation.Data> executeAsync(mutation: Mutation<T>): CompletableFuture<T>
+    fun <T : Query.Data> execute(query: Query<T>): T
+    fun <T : Mutation.Data> execute(mutation: Mutation<T>): T
 }

--- a/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/v2/LodgingSupplySandboxDataManagementClientUsageExample.java
+++ b/examples/src/main/java/com/expediagroup/sdk/lodgingconnectivity/v2/LodgingSupplySandboxDataManagementClientUsageExample.java
@@ -23,7 +23,8 @@ import com.expediagroup.sdk.v2.lodgingconnectivity.configuration.ClientEnvironme
 import com.expediagroup.sdk.v2.lodgingconnectivity.graphql.sandbox.SandboxDataManagementClient;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -59,59 +60,57 @@ public class LodgingSupplySandboxDataManagementClientUsageExample {
 
         //  ******* Create Property *******
         CreatePropertyInput createPropertyInput = CreatePropertyInput.builder().name(Optional.of(PROPERTY_NAME)).build();
-        var createPropertyResponse = client.execute(new SandboxCreatePropertyMutation(createPropertyInput));
+        SandboxCreatePropertyMutation.Data createPropertyResponse = client.executeAsync(new SandboxCreatePropertyMutation(createPropertyInput)).get();
 
 
-        var propertyId = createPropertyResponse.get().createProperty.property.id;
+        String propertyId = createPropertyResponse.createProperty.property.id;
 
         // ******* Update Property Name *******
-        var updatePropertyInput = UpdatePropertyInput.builder().id(propertyId).name(Optional.of(UPDATED_PROPERTY_NAME)).build();
-        var updatePropertyResponse = client.execute(new SandboxUpdatePropertyMutation(updatePropertyInput));
+        UpdatePropertyInput updatePropertyInput = UpdatePropertyInput.builder().id(propertyId).name(Optional.of(UPDATED_PROPERTY_NAME)).build();
+        SandboxUpdatePropertyMutation.Data updatePropertyResponse = client.executeAsync(new SandboxUpdatePropertyMutation(updatePropertyInput)).get();
 
         // ******* Create Reservation *******
-        var createReservationInput = CreateReservationInput.builder().propertyId(propertyId).childCount(Optional.of(4)).adultCount(Optional.of(2)).build();
-        var createReservationResponse = client.execute(new SandboxCreateReservationMutation(createReservationInput));
+        CreateReservationInput createReservationInput = CreateReservationInput.builder().propertyId(propertyId).childCount(Optional.of(4)).adultCount(Optional.of(2)).build();
+        SandboxCreateReservationMutation.Data createReservationResponse = client.executeAsync(new SandboxCreateReservationMutation(createReservationInput)).get();
 
 
-        var reservationId = createReservationResponse.get().createReservation.reservation.sandboxReservationFragment.id;
+        String reservationId = createReservationResponse.createReservation.reservation.sandboxReservationFragment.id;
 
         // ******* Update Reservation *******
-        var updateReservationInput = UpdateReservationInput.builder().id(reservationId).childAges(Optional.of(List.of(3, 5, 7))).build();
-        var updateReservationResponse = client.execute(new SandboxUpdateReservationMutation(updateReservationInput));
+        UpdateReservationInput updateReservationInput = UpdateReservationInput.builder().id(reservationId).childAges(Optional.of(new ArrayList<>(Arrays.asList(3, 5, 7)))).build();
+        SandboxUpdateReservationMutation.Data updateReservationResponse = client.executeAsync(new SandboxUpdateReservationMutation(updateReservationInput)).get();
 
         // ******* Update Reservation Stay Dates *******
-        var changeStayDatesInput = ChangeReservationStayDatesInput
+        ChangeReservationStayDatesInput changeStayDatesInput = ChangeReservationStayDatesInput
                 .builder()
                 .id(reservationId)
                 .checkInDate(LocalDate.of(2024, 6, 5))
                 .checkOutDate(LocalDate.of(2024, 6, 10))
                 .build();
 
-        var changeStayDatesResponse = client.execute(new SandboxChangeReservationStayDatesMutation(changeStayDatesInput));
+        SandboxChangeReservationStayDatesMutation.Data changeStayDatesResponse = client.executeAsync(new SandboxChangeReservationStayDatesMutation(changeStayDatesInput)).get();
 
         // ******* Cancel Reservation *******
-        var cancelReservationInput = CancelReservationInput.builder().id(reservationId).sendNotification(Optional.of(false)).build();
-        var cancelReservationResponse = client.execute(new SandboxCancelReservationMutation(cancelReservationInput));
+        CancelReservationInput cancelReservationInput = CancelReservationInput.builder().id(reservationId).sendNotification(Optional.of(false)).build();
+        SandboxCancelReservationMutation.Data cancelReservationResponse = client.executeAsync(new SandboxCancelReservationMutation(cancelReservationInput)).get();
 
         // ******* Delete Reservation *******
-        var deleteReservationInput = DeleteReservationInput.builder().id(reservationId).build();
-        var deleteReservationResponse = client.execute(new SandboxDeleteReservationMutation(deleteReservationInput));
+        DeleteReservationInput deleteReservationInput = DeleteReservationInput.builder().id(reservationId).build();
+        SandboxDeleteReservationMutation.Data deleteReservationResponse = client.executeAsync(new SandboxDeleteReservationMutation(deleteReservationInput)).get();
 
         // ******* Delete Property *******
-        var deletePropertyInput = DeletePropertyInput.builder().id(propertyId).build();
-        var deletePropertyResponse = client.execute(new SandboxDeletePropertyMutation(deletePropertyInput));
-
-//        System.exit(0);
+        DeletePropertyInput deletePropertyInput = DeletePropertyInput.builder().id(propertyId).build();
+        SandboxDeletePropertyMutation.Data deletePropertyResponse = client.executeAsync(new SandboxDeletePropertyMutation(deletePropertyInput)).get();
     }
 
     private static void deletePropertyIfExists() throws ExecutionException, InterruptedException {
-        var propertiesQuery = SandboxPropertiesQuery.builder().skipReservations(true).build();
-        var propertiesResponse = client.execute(propertiesQuery);
+        SandboxPropertiesQuery propertiesQuery = SandboxPropertiesQuery.builder().skipReservations(true).build();
+        SandboxPropertiesQuery.Data propertiesResponse = client.executeAsync(propertiesQuery).get();
 
-        propertiesResponse.get().properties.elements.forEach(property -> {
+        propertiesResponse.properties.elements.forEach(property -> {
             if (property.name.equals(PROPERTY_NAME) || property.name.equals(UPDATED_PROPERTY_NAME)) {
-                var deletePropertyInput = DeletePropertyInput.builder().id(property.id).build();
-                client.execute(new SandboxDeletePropertyMutation(deletePropertyInput));
+                DeletePropertyInput deletePropertyInput = DeletePropertyInput.builder().id(property.id).build();
+                client.executeAsync(new SandboxDeletePropertyMutation(deletePropertyInput));
             }
         });
     }


### PR DESCRIPTION
# Situation
We only have a single `execute` method which runs asynchronously and returns a `CompletableFuture`.

# Task
In order to unify the user interface, we need to proposer new synchronous `execute` methods on the `GraphQLExecutor` interface.

# Action
* Refactor the original `execute` methods name to `executeAsync`.
* Propose a new `execute` method, which calls the `.get()` method on the returned `CompletableFuture` instance returned by the `executeAsync` method.
* A few cleanups to documentation and unused params.

# Testing
TBA

# Results
We now have two models for executing a GraphQL request, `sync` and `async`. 

# Notes