### PR TITLE
feat: add mock utils

### DIFF
--- a/code/src/main/kotlin/com/expediagroup/sdk/core/client/SdkClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/client/SdkClient.kt
@@ -7,6 +7,7 @@ import com.expediagroup.sdk.core.jackson.deserialize
 import com.expediagroup.sdk.core.model.Operation
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
+import com.google.api.client.http.HttpTransport
 import java.io.InputStream
 
 /**
@@ -16,9 +17,11 @@ import java.io.InputStream
  */
 class SdkClient(
     configuration: FullClientConfiguration,
+    transport: HttpTransport? = null
 ) {
     val apiClient: ApiClient = createApiClient(
         configuration = configuration,
+        transport = transport
     )
 
     /**

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/BaseGraphQLClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/graphql/BaseGraphQLClient.kt
@@ -25,12 +25,17 @@ import com.expediagroup.sdk.core.configuration.FullClientConfiguration
 import com.expediagroup.sdk.core.client.ApiClientApolloHttpEngine
 import com.expediagroup.sdk.core.client.util.createApiClient
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
+import com.google.api.client.http.HttpTransport
 import java.util.concurrent.CompletableFuture
 
-class BaseGraphQLClient(configuration: FullClientConfiguration) : GraphQLExecutor {
+class BaseGraphQLClient(
+    configuration: FullClientConfiguration,
+    transport: HttpTransport? = null
+) : GraphQLExecutor {
     private val engine: ApiClientApolloHttpEngine = ApiClientApolloHttpEngine(
         createApiClient(
-            configuration = configuration
+            configuration = configuration,
+            transport = transport
         )
     )
 

--- a/code/src/test/kotlin/mocks/Endpoint.kt
+++ b/code/src/test/kotlin/mocks/Endpoint.kt
@@ -1,0 +1,7 @@
+package mocks
+
+object Endpoint {
+    const val BASE_URL: String = "http://example.com"
+    const val AUTHENTICATION_ENDPOINT = "$BASE_URL/auth"
+    const val API_ENDPOINT = "$BASE_URL/api"
+}

--- a/code/src/test/kotlin/mocks/MockTransport.kt
+++ b/code/src/test/kotlin/mocks/MockTransport.kt
@@ -1,0 +1,52 @@
+package mocks
+
+import com.google.api.client.http.LowLevelHttpRequest
+import com.google.api.client.testing.http.MockHttpTransport
+import com.google.api.client.testing.http.MockLowLevelHttpRequest
+import com.google.api.client.testing.http.MockLowLevelHttpResponse
+import java.util.Queue
+
+class MockTransport(
+    private val authResponse: MockLowLevelHttpResponse,
+    private val apiResponse: MockLowLevelHttpResponse
+): MockHttpTransport() {
+    override fun buildRequest(method: String?, url: String?): LowLevelHttpRequest {
+        requireNotNull(url)
+        requireNotNull(method)
+
+        val request: MockLowLevelHttpRequest = super.buildRequest(method, url) as MockLowLevelHttpRequest
+
+        request.response = if (request.url.equals(Endpoint.AUTHENTICATION_ENDPOINT)) {
+            apiResponse
+        } else {
+            apiResponse
+        }
+
+        return request
+    }
+}
+
+class QueuedMockTransport(
+    private val authResponses: Queue<MockLowLevelHttpResponse>,
+    private val apiResponses: Queue<MockLowLevelHttpResponse>
+): MockHttpTransport() {
+    private var mockTransport: MockTransport? = null
+
+    init {
+        require(authResponses.isNotEmpty()) { "authResponses must not be empty" }
+        require(apiResponses.isNotEmpty()) { "apiResponses must not be empty" }
+    }
+
+    private fun resetTransport() {
+        val authResponse = authResponses.poll()
+        val apiResponse = apiResponses.poll()
+
+        mockTransport = MockTransport(authResponse, apiResponse)
+    }
+
+    override fun buildRequest(method: String?, url: String?): LowLevelHttpRequest {
+        resetTransport()
+
+        return mockTransport!!.buildRequest(method, url)
+    }
+}

--- a/code/src/test/kotlin/mocks/MockTransport.kt
+++ b/code/src/test/kotlin/mocks/MockTransport.kt
@@ -17,7 +17,7 @@ class MockTransport(
         val request: MockLowLevelHttpRequest = super.buildRequest(method, url) as MockLowLevelHttpRequest
 
         request.response = if (request.url.equals(Endpoint.AUTHENTICATION_ENDPOINT)) {
-            apiResponse
+            authResponse
         } else {
             apiResponse
         }

--- a/code/src/test/kotlin/mocks/ResponseFactories.kt
+++ b/code/src/test/kotlin/mocks/ResponseFactories.kt
@@ -1,0 +1,59 @@
+package mocks
+
+import com.expediagroup.sdk.core.http.HttpStatus
+import com.google.api.client.auth.oauth2.TokenResponse
+import com.google.api.client.http.HttpStatusCodes
+import com.google.api.client.http.LowLevelHttpResponse
+import com.google.api.client.json.GenericJson
+import com.google.api.client.testing.http.MockLowLevelHttpResponse
+
+
+class AuthenticationResponseFactory {
+    companion object {
+        @JvmStatic
+        fun createSuccessful(
+            tokenResponse: TokenResponse
+        ): MockLowLevelHttpResponse =
+            MockLowLevelHttpResponse().apply {
+                setContentType("application/json")
+                setContent(tokenResponse.factory.toPrettyString(tokenResponse))
+
+                setStatusCode(200)
+                setReasonPhrase("Ok")
+            }
+
+        fun createUnsuccessful() =
+            MockLowLevelHttpResponse().apply {
+                setContentType("application/json")
+                setContent("Unsuccessful")
+                setStatusCode(401)
+            }
+    }
+}
+
+class ApiResponseFactory {
+    companion object {
+        @JvmStatic
+        fun createSuccessful(
+            headers: Map<String, Any> = emptyMap(),
+            body: GenericJson = GenericJson(),
+        ): LowLevelHttpResponse =
+            MockLowLevelHttpResponse().apply {
+                setContentType("application/json")
+
+                headers.forEach { (key, value) -> addHeader(key, value.toString()) }
+
+                setStatusCode(HttpStatusCodes.STATUS_CODE_OK)
+                setReasonPhrase("OK")
+                setContent(body.toPrettyString())
+            }
+
+        fun createUnsuccessful(errorStatus: HttpStatus) =
+            MockLowLevelHttpResponse().apply {
+                setContentType("application/json")
+                setStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
+                setReasonPhrase("Internal Server Error")
+                setContent("Unsuccessful")
+            }
+    }
+}

--- a/code/src/test/kotlin/mocks/TokenResponses.kt
+++ b/code/src/test/kotlin/mocks/TokenResponses.kt
@@ -1,0 +1,21 @@
+package mocks
+
+import com.google.api.client.auth.oauth2.TokenResponse
+
+
+// Our expiration threshold is 10 seconds
+val successfulTokenResponse = TokenResponse().apply {
+    setScope("example")
+    setRefreshToken("refresh_token")
+    setAccessToken("access_token")
+    setExpiresInSeconds(3600)
+    setTokenType("token_type")
+}
+
+val aboutToExpireSuccessfulTokenResponse = successfulTokenResponse.clone().apply {
+    setExpiresInSeconds(9)
+}
+
+val oneSecondForAboutToExpireSuccessfulTokenResponse = successfulTokenResponse.clone().apply {
+    setExpiresInSeconds(11)
+}


### PR DESCRIPTION
# Situation
We agreed to start adding tests to our new core. We also agreed to avoid mocking anything except for the HTTP transport layer.

# Task
Create tools for mocking HTTP transport layer.

# Action
* Created `MockTransport` which can be passed to `BaseGraphQLClient` and `SdkClient`.
* Created response factories for mocking responses based on predefined endpoints in the configurations.

# Testing
TBA

# Results
Can now go on with testing our core.

# Notes
* Please use the endpoints provided in the `Endpoints.kt` file for building any client when testing.