### PR TITLE
feat: auto approve bot prs

### DIFF
--- a/.github/workflows/pr-auto-approve.yaml
+++ b/.github/workflows/pr-auto-approve.yaml
@@ -1,0 +1,16 @@
+name: Auto First Approval for Bot PRs
+on: pull_request
+
+jobs:
+  auto-first-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
+    steps:
+      - name: Provide first approval
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          review-message: "Renovate and Dependabot PRs are automatically approved. Still requires human review."


### PR DESCRIPTION
# Situation
The repository currently requires 2 approvals for all pull requests. However, to reduce friction, only 1 approval should be required for pull requests made by bot accounts like Dependabot and Renovate.

# Task
The goal is to configure the repository to automatically provide the first approval for pull requests made by trusted bot accounts while requiring a second human approval before merging.

# Action
A GitHub Actions workflow was created in the `.github/workflows/pr-auto-approve.yml` file. This workflow:
1. Runs on all pull request events
2. Check if the pull request author is one of the trusted bot accounts (Dependabot, Renovate)
3. If so, it automatically provides the first approval using the `hmarr/auto-approve-action`

# Testing
Tested manually on another repo.

# Results
With this configuration, pull requests from trusted bot accounts will only require 1 additional human approval before merging, instead of the usual 2. This reduces friction for routine updates while maintaining a level of human review.