### PR TITLE
fix: restructure Gradle setup

### DIFF
--- a/apollo-compiler-plugin/build.gradle
+++ b/apollo-compiler-plugin/build.gradle
@@ -1,3 +1,12 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
+    id 'com.apollographql.apollo' version '4.1.0'
+}
+
+kotlin {
+    jvmToolchain(8)
+}
+
 dependencies {
     implementation 'com.apollographql.apollo:apollo-compiler:4.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,23 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
 }
 
 subprojects {
     /* Shared plugins between all modules */
     apply plugin: 'java'
-    apply plugin: 'org.jetbrains.kotlin.jvm'
 
     /* Shared repositories between all modules */
     repositories {
         mavenCentral()
     }
 
-    kotlin {
-        jvmToolchain(8)
-    }
-
     java {
         withSourcesJar()
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(8))
+        }
     }
 }

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'org.jetbrains.kotlin.jvm' version '2.0.21'
     id 'org.jetbrains.dokka' version '1.9.20'
     id 'com.apollographql.apollo' version '4.1.0'
 
@@ -7,7 +8,11 @@ plugins {
     id 'signing'
 
     /* Test Reporting */
-    id("org.jetbrains.kotlinx.kover") version "0.8.3"
+    id 'org.jetbrains.kotlinx.kover' version "0.8.3"
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 jar {
@@ -28,7 +33,7 @@ test {
 }
 
 tasks.named("check") {
-    finalizedBy("koverHtmlReport", "koverXmlReport")
+    finalizedBy("koverHtmlReport")
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.6.0'
+}
+
 rootProject.name = "lodging-connectivity-sdk" // Used as published artifactId
 
 include 'code'


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
We've been facing some Java versions incompatibility issues when attempting to compile the project and targeting Java 8. This PR fixes these issues and offer more automation on the Gradle setup

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
Resolve compilation issues related to the targeted JVM, Gradle Version, the JVM Gradle runs on.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
1. Added `org.gradle.toolchains.foojay-resolver-convention` plugin to auto-pull the JVM toolchain needed for the compilation, omitting the need for users to manually configure the environment.
2. Applied the `kotlin` plugin on each module individually. Mainly to turn off the annoying red lines errors in IntelliJ Gradle UI.
3. Added `languageVersion.set(JavaLanguageVersion.of(8))` for stricter Java 8 enforcement.

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
The project compiles successfully.

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
The project compiles with the current & newer Gradle versions.