### PR TITLE
feat: support SDK metadata loading and setting user-agent headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ subprojects {
     /* Shared repositories between all modules */
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 
     java {

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -15,17 +15,6 @@ kotlin {
     jvmToolchain(8)
 }
 
-test {
-    useJUnitPlatform()
-    testLogging {
-        events "passed", "skipped", "failed"
-    }
-}
-
-tasks.named("check") {
-    finalizedBy("koverHtmlReport")
-}
-
 dependencies {
     /* Kotlin */
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.1.0'
@@ -52,6 +41,7 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.13.13'
 }
 
+apply from: "tasks-gradle/test.gradle"
 apply from: "tasks-gradle/sdk-properties.gradle"
 apply from: "tasks-gradle/apollo.gradle"
 apply from: "tasks-gradle/publishing.gradle"

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -15,16 +15,6 @@ kotlin {
     jvmToolchain(8)
 }
 
-jar {
-    manifest {
-        attributes(
-                "version": version,
-                "artifactId": rootProject.name,
-                "userAgentPrefix": "expediagroup-sdk-java-${rootProject.name.replaceFirst("-sdk", "")}"
-        )
-    }
-}
-
 test {
     useJUnitPlatform()
     testLogging {
@@ -62,6 +52,7 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.13.13'
 }
 
+apply from: "tasks-gradle/sdk-properties.gradle"
 apply from: "tasks-gradle/apollo.gradle"
 apply from: "tasks-gradle/publishing.gradle"
 apply from: "tasks-gradle/dokka.gradle"

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.core.common
+
+import java.util.Locale
+import java.util.Properties
+
+/**
+ * A utility object that scans the classpath for `sdk.properties` file.
+ */
+internal object MetadataLoader {
+    val artifactName: String
+    val groupId: String
+    val version: String
+    val jdkVersion: String
+    val jdkVendor: String
+    val osName: String
+    val osVersion: String
+    val arch: String
+    val locale: String
+
+    const val UNKNOWN = "unknown"
+
+    init {
+        val props = Properties()
+
+        this::class.java.classLoader.getResourceAsStream("sdk.properties")?.use {
+            props.load(it)
+        }
+
+        artifactName = props.getProperty("artifactName", UNKNOWN)
+        groupId = props.getProperty("groupId", UNKNOWN)
+        version = props.getProperty("version", UNKNOWN)
+        jdkVersion = System.getProperty("java.version", UNKNOWN)
+        jdkVendor = System.getProperty("java.vendor", UNKNOWN)
+        osName = System.getProperty("os.name", UNKNOWN)
+        osVersion = System.getProperty("os.version", UNKNOWN)
+        arch = System.getProperty("os.arch", UNKNOWN)
+        locale = Locale.getDefault().toString()
+    }
+
+    /**
+     * Builds a `User-Agent` string from the loaded metadata.
+     *
+     * Format:
+     * `userAgentPrefix/version (Provider/artifactId; Java/jdkVersion; Vendor/jdkVendor; OS/osName - osVersion; Arch/arch; Locale/locale)`
+     */
+    fun asUserAgentString(): String {
+        return "$artifactName/$version (Provider/$groupId; Java/$jdkVersion; Vendor/$jdkVendor; OS/$osName - $osVersion; Arch/$arch; Locale/$locale)"
+    }
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
@@ -19,6 +19,10 @@ package com.expediagroup.sdk.core.common
 import java.util.Locale
 import java.util.Properties
 
+/**
+ * Utility object for loading SDK metadata from the generated `sdk.properties` file along with other
+ * system properties like JVM info and host OS info.
+ */
 internal object MetadataLoader {
     private const val UNKNOWN = "unknown"
 

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
@@ -27,28 +27,14 @@ internal object MetadataLoader {
     private const val UNKNOWN = "unknown"
 
     @Volatile
+    @set:Synchronized
     private var cachedMetadata: Metadata? = null
 
     /**
      * Loads the SDK metadata from sdk.properties file and caches the results for future calls.
-     *
-     * Call [MetadataLoader.reload()] to clear the cache and read the metadata again
-     *
-     * @see [MetadataLoader.reload]
      */
     fun load(): Metadata {
-        return cachedMetadata ?: synchronized(this) {
-            readPropertiesFile().also { cachedMetadata = it }
-        }
-    }
-
-    /**
-     * Clears the cached metadata and attempts to reload
-     */
-    @Synchronized
-    fun reload(): Metadata {
-        cachedMetadata = null
-        return load()
+        return cachedMetadata ?: readPropertiesFile().also { cachedMetadata = it }
     }
 
     /**

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/MetadataLoader.kt
@@ -27,14 +27,15 @@ internal object MetadataLoader {
     private const val UNKNOWN = "unknown"
 
     @Volatile
-    @set:Synchronized
     private var cachedMetadata: Metadata? = null
 
     /**
      * Loads the SDK metadata from sdk.properties file and caches the results for future calls.
      */
     fun load(): Metadata {
-        return cachedMetadata ?: readPropertiesFile().also { cachedMetadata = it }
+        return cachedMetadata ?: synchronized(this) {
+            cachedMetadata ?: readPropertiesFile().also { cachedMetadata = it }
+        }
     }
 
     /**

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptor.kt
@@ -25,8 +25,10 @@ import com.expediagroup.sdk.core.interceptor.Interceptor
 class RequestHeadersInterceptor : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
+        val metadata = MetadataLoader.load()
+
         val request = chain.request().newBuilder()
-            .setHeader("User-Agent", MetadataLoader.asUserAgentString())
+            .setHeader("User-Agent", metadata.asUserAgentString())
             .build()
 
         return chain.proceed(request)

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptor.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.expediagroup.sdk.core.common
+
+import com.expediagroup.sdk.core.http.Response
+import com.expediagroup.sdk.core.interceptor.Interceptor
+
+/**
+ * Interceptor for setting required headers before executing the request
+ */
+class RequestHeadersInterceptor : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+            .setHeader("User-Agent", MetadataLoader.asUserAgentString())
+            .build()
+
+        return chain.proceed(request)
+    }
+}

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/logging/common/ResponseLogger.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/logging/common/ResponseLogger.kt
@@ -40,6 +40,11 @@ object ResponseLogger {
 
         val buffer = Buffer()
         val bytesToRead = minOf(maxSize, this.contentLength())
+
+        if (bytesToRead <= 0) {
+            return ""
+        }
+
         this.source().peek().read(buffer, bytesToRead)
         return buffer.readString(charset ?: Charsets.UTF_8)
     }

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/logging/common/ResponseLogger.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/logging/common/ResponseLogger.kt
@@ -40,11 +40,6 @@ object ResponseLogger {
 
         val buffer = Buffer()
         val bytesToRead = minOf(maxSize, this.contentLength())
-
-        if (bytesToRead <= 0) {
-            return ""
-        }
-
         this.source().peek().read(buffer, bytesToRead)
         return buffer.readString(charset ?: Charsets.UTF_8)
     }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/common/DefaultRequestExecutor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/common/DefaultRequestExecutor.kt
@@ -5,6 +5,7 @@ import com.expediagroup.sdk.core.authentication.bearer.BearerAuthenticationManag
 import com.expediagroup.sdk.core.authentication.common.Credentials
 import com.expediagroup.sdk.core.client.RequestExecutor
 import com.expediagroup.sdk.core.client.Transport
+import com.expediagroup.sdk.core.common.RequestHeadersInterceptor
 import com.expediagroup.sdk.core.http.Request
 import com.expediagroup.sdk.core.http.Response
 import com.expediagroup.sdk.core.interceptor.Interceptor
@@ -28,6 +29,7 @@ class DefaultRequestExecutor(
 ) : RequestExecutor(getHttpTransport(configuration)) {
 
     override val interceptors: List<Interceptor> = listOf(
+        RequestHeadersInterceptor(),
         LoggingInterceptor(),
         BearerAuthenticationInterceptor(
             BearerAuthenticationManager(

--- a/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
@@ -45,6 +45,12 @@ class MetadataLoaderTest {
             assertEquals("unknown", metadata.artifactName)
             assertEquals("unknown", metadata.groupId)
             assertEquals("unknown", metadata.version)
+            assertNotNull(metadata.jdkVersion)
+            assertNotNull(metadata.jdkVendor)
+            assertNotNull(metadata.osName)
+            assertNotNull(metadata.osVersion)
+            assertNotNull(metadata.arch)
+            assertNotNull(metadata.locale)
         } finally {
             Thread.currentThread().contextClassLoader = originalClassLoader
         }
@@ -62,6 +68,12 @@ class MetadataLoaderTest {
             assertEquals("unknown", metadata.artifactName)
             assertEquals("unknown", metadata.groupId)
             assertEquals("unknown", metadata.version)
+            assertNotNull(metadata.jdkVersion)
+            assertNotNull(metadata.jdkVendor)
+            assertNotNull(metadata.osName)
+            assertNotNull(metadata.osVersion)
+            assertNotNull(metadata.arch)
+            assertNotNull(metadata.locale)
         } finally {
             Thread.currentThread().contextClassLoader = originalClassLoader
         }

--- a/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
@@ -1,0 +1,14 @@
+package com.expediagroup.sdk.core.common
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MetadataLoaderTest {
+
+    @Test
+    fun `should load metadata from sdk properties file`() {
+        assertEquals("com.expediagroup", MetadataLoader.groupId)
+        assertEquals("expedia-group-test-sdk", MetadataLoader.artifactName)
+        assertEquals("1.0.0", MetadataLoader.version)
+    }
+}

--- a/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/common/MetadataLoaderTest.kt
@@ -1,14 +1,74 @@
 package com.expediagroup.sdk.core.common
 
+import java.io.InputStream
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
 
 class MetadataLoaderTest {
 
+    @AfterEach
+    fun tearDown() {
+        MetadataLoader.clear()
+    }
+
     @Test
     fun `should load metadata from sdk properties file`() {
-        assertEquals("com.expediagroup", MetadataLoader.groupId)
-        assertEquals("expedia-group-test-sdk", MetadataLoader.artifactName)
-        assertEquals("1.0.0", MetadataLoader.version)
+        val metadata = MetadataLoader.load()
+
+        assertEquals("com.expediagroup", metadata.groupId)
+        assertEquals("expedia-group-test-sdk", metadata.artifactName)
+        assertEquals("1.0.0", metadata.version)
+        assertNotNull(metadata.jdkVersion)
+        assertNotNull(metadata.jdkVendor)
+        assertNotNull(metadata.osName)
+        assertNotNull(metadata.osVersion)
+        assertNotNull(metadata.arch)
+        assertNotNull(metadata.locale)
+    }
+
+    @Test
+    fun `should load default metadata if no sdk properties file is found`() {
+        val originalClassLoader = Thread.currentThread().contextClassLoader
+
+        try {
+            Thread.currentThread().contextClassLoader = object : ClassLoader(originalClassLoader) {
+                override fun getResourceAsStream(name: String?): InputStream? {
+                    return if (name == "sdk.properties") null else super.getResourceAsStream(name)
+                }
+            }
+
+            val metadata = MetadataLoader.load()
+
+            assertEquals("unknown", metadata.artifactName)
+            assertEquals("unknown", metadata.groupId)
+            assertEquals("unknown", metadata.version)
+        } finally {
+            Thread.currentThread().contextClassLoader = originalClassLoader
+        }
+    }
+
+    @Test
+    fun `should load default metadata if failed to get the current thread class loader`() {
+        val originalClassLoader = Thread.currentThread().contextClassLoader
+
+        try {
+            Thread.currentThread().contextClassLoader = null
+
+            val metadata = MetadataLoader.load()
+
+            assertEquals("unknown", metadata.artifactName)
+            assertEquals("unknown", metadata.groupId)
+            assertEquals("unknown", metadata.version)
+        } finally {
+            Thread.currentThread().contextClassLoader = originalClassLoader
+        }
+    }
+
+    @Test
+    fun `should return the same metadata instance if called multiple times`() {
+        assertSame(MetadataLoader.load(), MetadataLoader.load())
     }
 }

--- a/code/src/test/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptorTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/common/RequestHeadersInterceptorTest.kt
@@ -1,0 +1,41 @@
+package com.expediagroup.sdk.core.common
+
+import com.expediagroup.sdk.core.http.Method
+import com.expediagroup.sdk.core.http.Protocol
+import com.expediagroup.sdk.core.http.Request
+import com.expediagroup.sdk.core.http.Response
+import com.expediagroup.sdk.core.http.Status
+import com.expediagroup.sdk.core.interceptor.Interceptor
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RequestHeadersInterceptorTest {
+
+    @Test
+    fun `should add User-Agent header to the request`() {
+        val interceptor = RequestHeadersInterceptor()
+
+        val chain = object : Interceptor.Chain {
+            override fun request(): Request = Request.builder()
+                .url("https://example.com")
+                .method(Method.GET)
+                .build()
+
+            override fun proceed(request: Request): Response = Response
+                .builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .status(Status.OK)
+                .message("OK")
+                .build()
+        }
+
+        // When
+        val response = interceptor.intercept(chain)
+        val userAgentHeader = response.request.headers.get("User-Agent")!!
+
+        // Expect
+        assertTrue(userAgentHeader.contains("expedia-group-test-sdk/1.0.0"))
+        assertTrue(userAgentHeader.contains("Provider/com.expediagroup;"))
+    }
+}

--- a/code/src/test/resources/sdk.properties
+++ b/code/src/test/resources/sdk.properties
@@ -1,0 +1,3 @@
+artifactName=expedia-group-test-sdk
+version=1.0.0
+groupId=com.expediagroup

--- a/code/tasks-gradle/sdk-properties.gradle
+++ b/code/tasks-gradle/sdk-properties.gradle
@@ -1,0 +1,11 @@
+def artifactName = project.findProperty("artifactName") ?: "unknown"
+def version = project.findProperty("version") ?: "unknown"
+def groupId = project.findProperty("groupId") ?: "unknown"
+
+def sdkPropertiesContent = "artifactName=${artifactName}\nversion=${version}\ngroupId=${groupId}".stripIndent()
+
+processResources {
+    from(project.resources.text.fromString(sdkPropertiesContent)) {
+        rename { "sdk.properties" }
+    }
+}

--- a/code/tasks-gradle/test.gradle
+++ b/code/tasks-gradle/test.gradle
@@ -1,0 +1,14 @@
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+    classpath = classpath.filter {
+        // Prevents the tests from being aware of any resources files that are NOT related to the tests
+        !it.absolutePath.contains("build/resources/main/sdk.properties")
+    }
+}
+
+tasks.named("check") {
+    finalizedBy("koverHtmlReport")
+}


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
We need a way to identify the environment the SDK is working in, including the SDK version, artifact name, and other host system properties like OS name and version.

These loaded metadata will typically used as `User-Agent` header in the outgoing requests.

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
1. Build a utility that loads the required SDK metadata with minimal overhead.
2. Ensure that all requests has correct `User-Agent` header.

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->

### `MetadataLoader` Object
Utility object for loading SDK metadata from the generated `sdk.properties` file along with other
system properties like JVM info and host OS info.

**Usage**
1. Call `MetadataLoader.load()` to read the `sdk.properties` file. The loaded metadata will be cached by default and any subsequent calls will return the same `Metadata` instance.
2. Call `MetadataLoader.clear()` to clear the cached data.

<hr />

### `RequestHeadersInterceptor` Class
An `Interceptor` implementation for setting required headers before executing the request within the SDK. Used to set the `User-Agent` header from the loaded metadata.

<hr />

### Generate `sdk.properties` File
Created a new Gradle task in `code/tasks-gradle/sdk-properties.gradle` to generate the `sdk.properties` file at build time. This file is placed into the artifact resources and visible in the classpath.

<hr />

### `code/tasks-gradle/test.gradle` File
1. Moved all test-related Gradle configurations to a separate file `code/tasks-gradle/test.gradle` and imported it in the root `build.gradle`. 
2. Added a small script to exclude build resource `[build/resources/main/sdk.properties]` from being visible during the tests execution for better isolation.

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
1. Manually verified the results on local runs
4. Manually verified the results by publishing a version to `mavenLocal()` and install it in a scratch project.
5. Added unit tests for `MetadataLoader` and `RequestHeadersInterceptor` with 100% coverage.

# Results
<!-- Detail the outcomes of the actions. What improvements or changes have been achieved? Include performance gains, bug fixes, or other tangible outcomes. How will you measure or verify success? -->
1. SDK metadata are loaded by the `MetadataLoader` object.
2. The `sdk.properties` file is generated at build time.
3. The `User-Agent` header is set in all SDK requests.

#### User-Agent Header Logs
<img width="1334" alt="Screenshot 2024-12-12 at 12 15 30" src="https://github.com/user-attachments/assets/f106a2eb-64ae-45f5-aeff-706c3b6a975f" />
