### PR TITLE
chore: cleanup iteration

### DIFF
--- a/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationInterceptor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationInterceptor.kt
@@ -47,7 +47,6 @@ class BearerAuthenticationInterceptor(
      * @return The [Response] resulting from the executed request.
      * @throws ExpediaGroupAuthException If authentication fails due to invalid credentials or server errors
      */
-    @Throws(ExpediaGroupAuthException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
 
@@ -75,7 +74,6 @@ class BearerAuthenticationInterceptor(
      *
      * @throws ExpediaGroupAuthException If authentication fails
      */
-    @Throws(ExpediaGroupAuthException::class)
     private fun ensureValidAuthentication() {
         try {
             if (authManager.isTokenAboutToExpire()) {

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManager.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManager.kt
@@ -26,7 +26,6 @@ import com.expediagroup.sdk.core.http.RequestBody
 import com.expediagroup.sdk.core.http.Response
 import com.expediagroup.sdk.core.model.exception.client.ExpediaGroupResponseParsingException
 import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupAuthException
-import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupNetworkException
 
 /**
  * Manages bearer token authentication for HTTP requests.
@@ -57,7 +56,6 @@ class BearerAuthenticationManager(
      * @throws ExpediaGroupAuthException If the authentication request fails.
      * @throws ExpediaGroupResponseParsingException If the response cannot be parsed.
      */
-    @Throws(ExpediaGroupAuthException::class, ExpediaGroupResponseParsingException::class)
     override fun authenticate() {
         clearAuthentication()
             .let {
@@ -120,7 +118,6 @@ class BearerAuthenticationManager(
      * @return The [Response] received from the server.
      * @throws ExpediaGroupAuthException If the server responds with an error.
      */
-    @Throws(ExpediaGroupAuthException::class, ExpediaGroupNetworkException::class)
     private fun executeAuthenticationRequest(request: Request): Response = run {
         requestExecutor.execute(request).apply {
             if (!this.isSuccessful) {

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/TokenResponse.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/bearer/TokenResponse.kt
@@ -51,7 +51,6 @@ data class TokenResponse(
          * @return A [TokenResponse] object containing the token and its metadata.
          * @throws ExpediaGroupResponseParsingException If the response cannot be parsed.
          */
-        @Throws(ExpediaGroupResponseParsingException::class)
         fun parse(response: Response): TokenResponse {
             val responseBody = response.body.getOrThrow {
                 ExpediaGroupResponseParsingException("Authenticate response body is empty or cannot be parsed")

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/common/AuthenticationManager.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/authentication/common/AuthenticationManager.kt
@@ -38,11 +38,6 @@ interface AuthenticationManager {
      * @throws ExpediaGroupResponseParsingException If the authentication response cannot be parsed
      * @throws ExpediaGroupNetworkException If a network error occurs during authentication
      */
-    @Throws(
-        ExpediaGroupAuthException::class,
-        ExpediaGroupResponseParsingException::class,
-        ExpediaGroupNetworkException::class
-    )
     fun authenticate()
 
     /**

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/client/RequestExecutor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/client/RequestExecutor.kt
@@ -73,6 +73,5 @@ abstract class RequestExecutor(protected val transport: Transport) {
      * @return The response from the server after passing through interceptors
      * @throws ExpediaGroupNetworkException If any network-related error occurs
      */
-    @Throws(ExpediaGroupNetworkException::class)
     abstract fun execute(request: Request): Response
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/client/Transport.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/client/Transport.kt
@@ -58,6 +58,5 @@ interface Transport {
      * @return The response from the server wrapped in the SDK response model
      * @throws ExpediaGroupNetworkException If any network-related error occurs during execution
      */
-    @Throws(ExpediaGroupNetworkException::class)
     fun execute(request: Request): Response
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/http/Headers.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/http/Headers.kt
@@ -21,7 +21,8 @@ import java.util.Locale
 /**
  * Represents a collection of HTTP headers.
  */
-class Headers private constructor(private val headersMap: Map<String, List<String>>) {
+@ConsistentCopyVisibility
+data class Headers private constructor(private val headersMap: Map<String, List<String>>) {
 
     /**
      * Returns the first header value for the given name, or null if none.
@@ -96,7 +97,6 @@ class Headers private constructor(private val headersMap: Map<String, List<Strin
          * @return this builder
          * @throws IllegalArgumentException if [name] or [value] is invalid
          */
-        @Throws(IllegalArgumentException::class)
         fun add(name: String, value: String): Builder = apply { add(sanitizeName(name), listOf(value)) }
 
         /**
@@ -107,7 +107,6 @@ class Headers private constructor(private val headersMap: Map<String, List<Strin
          * @return this builder
          * @throws IllegalArgumentException if [name] or any [values] are invalid
          */
-        @Throws(IllegalArgumentException::class)
         fun add(name: String, values: List<String>): Builder = apply {
             headersMap.computeIfAbsent(sanitizeName(name)) { mutableListOf() }.addAll(values)
         }
@@ -121,7 +120,6 @@ class Headers private constructor(private val headersMap: Map<String, List<Strin
          * @return this builder
          * @throws IllegalArgumentException if [name] or [value] is invalid
          */
-        @Throws(IllegalArgumentException::class)
         fun set(name: String, value: String): Builder = apply { set(sanitizeName(name), listOf(value)) }
 
         /**
@@ -133,7 +131,6 @@ class Headers private constructor(private val headersMap: Map<String, List<Strin
          * @return this builder
          * @throws IllegalArgumentException if [name] or [values] are invalid
          */
-        @Throws(IllegalArgumentException::class)
         fun set(name: String, values: List<String>): Builder = apply {
             remove(sanitizeName(name))
             add(sanitizeName(name), values)

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/http/MediaType.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/http/MediaType.kt
@@ -26,8 +26,8 @@ import java.util.Locale
  * @property subtype The subtype (e.g., "json", "plain").
  * @property parameters The map of parameters associated with the media type (e.g., charset).
  */
-
-class MediaType private constructor(
+@ConsistentCopyVisibility
+data class MediaType private constructor(
     val type: String,
     val subtype: String,
     val parameters: Map<String, String> = emptyMap()

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/http/Request.kt
@@ -24,7 +24,8 @@ import java.net.URL
  *
  * Use [Request.builder()] to create an instance.
  */
-class Request private constructor(
+@ConsistentCopyVisibility
+data class Request private constructor(
     val method: Method,
     val url: URL,
     val headers: Headers,

--- a/code/src/main/kotlin/com/expediagroup/sdk/core/http/Response.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/core/http/Response.kt
@@ -24,7 +24,8 @@ import java.io.IOException
  *
  * Use [Builder] to create an instance.
  */
-class Response private constructor(
+@ConsistentCopyVisibility
+data class Response private constructor(
     val request: Request,
     val protocol: Protocol,
     val status: Status,

--- a/code/src/main/kotlin/com/expediagroup/sdk/graphql/common/DefaultGraphQLExecutor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/graphql/common/DefaultGraphQLExecutor.kt
@@ -63,7 +63,6 @@ internal class DefaultGraphQLExecutor(requestExecutor: RequestExecutor, serverUr
      * @throws [ExpediaGroupServiceException] If an exception occurs during query execution.
      * @throws [NoDataException] If the query completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     override fun <T : Query.Data> executeAsync(query: Query<T>): CompletableFuture<RawResponse<T>> {
         return CompletableFuture<RawResponse<T>>().also {
             apolloClient.query(query).enqueue { response -> processOperationResponse(response, it) }
@@ -78,7 +77,6 @@ internal class DefaultGraphQLExecutor(requestExecutor: RequestExecutor, serverUr
      * @throws [ExpediaGroupServiceException] If an exception occurs during query execution.
      * @throws [NoDataException] If the query completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     override fun <T : Query.Data> execute(query: Query<T>): RawResponse<T> = executeAsync(query).get()
 
     /**
@@ -90,7 +88,6 @@ internal class DefaultGraphQLExecutor(requestExecutor: RequestExecutor, serverUr
      * @throws [ExpediaGroupServiceException] If an exception occurs during mutation execution.
      * @throws [NoDataException] If the mutation completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     override fun <T : Mutation.Data> executeAsync(mutation: Mutation<T>): CompletableFuture<RawResponse<T>> {
         return CompletableFuture<RawResponse<T>>().also {
             apolloClient.mutation(mutation).enqueue { response -> processOperationResponse(response, it) }
@@ -105,7 +102,6 @@ internal class DefaultGraphQLExecutor(requestExecutor: RequestExecutor, serverUr
      * @throws [ExpediaGroupServiceException] If an exception occurs during mutation execution.
      * @throws [NoDataException] If the mutation completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     override fun <T : Mutation.Data> execute(mutation: Mutation<T>): RawResponse<T> = executeAsync(mutation).get()
 
 

--- a/code/src/main/kotlin/com/expediagroup/sdk/graphql/common/GraphQLExecutor.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/graphql/common/GraphQLExecutor.kt
@@ -48,7 +48,6 @@ abstract class GraphQLExecutor {
      * @throws [ExpediaGroupServiceException] If an exception occurs during the execution of the query.
      * @throws [NoDataException] If the query completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     abstract fun <T : Query.Data> execute(query: Query<T>): RawResponse<T>
 
     /**
@@ -59,7 +58,6 @@ abstract class GraphQLExecutor {
      * @throws [ExpediaGroupServiceException] If an exception occurs during the execution of the mutation.
      * @throws [NoDataException] If the mutation completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     abstract fun <T : Mutation.Data> execute(mutation: Mutation<T>): RawResponse<T>
 
     /**
@@ -70,7 +68,6 @@ abstract class GraphQLExecutor {
      * @throws [ExpediaGroupServiceException] If an exception occurs during the execution of the query.
      * @throws [NoDataException] If the query completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     abstract fun <T : Query.Data> executeAsync(query: Query<T>): CompletableFuture<RawResponse<T>>
 
     /**
@@ -81,6 +78,5 @@ abstract class GraphQLExecutor {
      * @throws [ExpediaGroupServiceException] If an exception occurs during the execution of the mutation.
      * @throws [NoDataException] If the mutation completes without data but includes errors.
      */
-    @Throws(NoDataException::class, ExpediaGroupServiceException::class)
     abstract fun <T : Mutation.Data> executeAsync(mutation: Mutation<T>): CompletableFuture<RawResponse<T>>
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/payment/PaymentClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/payment/PaymentClient.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.payment
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.DefaultGraphQLExecutor
 import com.expediagroup.sdk.graphql.common.GraphQLClient
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
@@ -23,6 +24,7 @@ import com.expediagroup.sdk.lodgingconnectivity.common.DefaultRequestExecutor
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientConfiguration
 import com.expediagroup.sdk.lodgingconnectivity.configuration.ClientEnvironment
 import com.expediagroup.sdk.lodgingconnectivity.configuration.PaymentApiEndpointProvider
+import com.expediagroup.sdk.lodgingconnectivity.payment.operation.GetPaymentInstrumentResponse
 import com.expediagroup.sdk.lodgingconnectivity.payment.operation.PaymentInstrumentQuery
 import com.expediagroup.sdk.lodgingconnectivity.payment.operation.getPaymentInstrumentOperation
 
@@ -54,7 +56,7 @@ class PaymentClient(config: ClientConfiguration) : GraphQLClient() {
      * @return A [GetPaymentInstrumentResponse] containing the requested payment instrument data and the full raw response.
      * @throws ExpediaGroupServiceException If the payment instrument data is not found in the response.
      */
-    fun getPaymentInstrument(token: String) = run {
+    fun getPaymentInstrument(token: String): GetPaymentInstrumentResponse = run {
         getPaymentInstrumentOperation(graphQLExecutor, token)
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/payment/operation/GetPaymentInstrumentOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/payment/operation/GetPaymentInstrumentOperation.kt
@@ -47,7 +47,7 @@ data class GetPaymentInstrumentResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL query.
  * @param token The token identifying the payment instrument to be retrieved.
  * @return A [GetPaymentInstrumentResponse] containing the requested payment instrument data and the full raw response.
- * @throws ExpediaGroupServiceException If the payment instrument data is not found in the response.
+ * @throws [ExpediaGroupServiceException] If the payment instrument data is not found in the response.
  */
 fun getPaymentInstrumentOperation(graphQLExecutor: GraphQLExecutor, token: String): GetPaymentInstrumentResponse {
     val operation = PaymentInstrumentQuery(token)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/SandboxDataManagementClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/SandboxDataManagementClient.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.DefaultGraphQLExecutor
 import com.expediagroup.sdk.graphql.common.GraphQLClient
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
@@ -74,7 +75,8 @@ import com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.paginator.Sa
  * or timeouts.
  */
 class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient() {
-    override val apiEndpoint = SandboxApiEndpointProvider.forEnvironment(config.environment ?: ClientEnvironment.SANDBOX_PROD)
+    override val apiEndpoint =
+        SandboxApiEndpointProvider.forEnvironment(config.environment ?: ClientEnvironment.SANDBOX_PROD)
 
     override val graphQLExecutor: GraphQLExecutor = DefaultGraphQLExecutor(
         requestExecutor = DefaultRequestExecutor(config, apiEndpoint),
@@ -85,9 +87,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      * Retrieves all sandbox properties in one page.
      *
      * @return A [GetSandboxPropertiesResponse] containing the sandbox properties data, pagination information, and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun getProperties() = run {
+    fun getProperties(): GetSandboxPropertiesResponse = run {
         getSandboxPropertiesOperation(graphQLExecutor)
     }
 
@@ -99,7 +101,7 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      * @return A [SandboxPropertiesPaginator] for iterating through properties.
      */
     @JvmOverloads
-    fun getPropertiesPaginator(pageSize: Int, initialCursor: String? = null) = run {
+    fun getPropertiesPaginator(pageSize: Int, initialCursor: String? = null): SandboxPropertiesPaginator = run {
         SandboxPropertiesPaginator(graphQLExecutor, pageSize, initialCursor)
     }
 
@@ -108,9 +110,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param propertyId The unique identifier of the property.
      * @return A [GetSandboxReservationsResponse] containing the sandbox reservations data, pagination information, and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun getReservations(propertyId: String) = run {
+    fun getReservations(propertyId: String): GetSandboxReservationsResponse = run {
         getSandboxReservationsOperation(graphQLExecutor, propertyId)
     }
 
@@ -123,7 +125,11 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      * @return A [SandboxReservationsPaginator] for iterating through reservations.
      */
     @JvmOverloads
-    fun getReservationsPaginator(propertyId: String, pageSize: Int, initialCursor: String? = null) = run {
+    fun getReservationsPaginator(
+        propertyId: String,
+        pageSize: Int,
+        initialCursor: String? = null
+    ): SandboxReservationsPaginator = run {
         SandboxReservationsPaginator(graphQLExecutor, propertyId, pageSize, initialCursor)
     }
 
@@ -132,9 +138,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param propertyId The unique identifier of the property.
      * @return A [GetSandboxPropertyResponse] containing the requested sandbox property data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun getProperty(propertyId: String) = run {
+    fun getProperty(propertyId: String): GetSandboxPropertyResponse = run {
         getSandboxPropertyOperation(graphQLExecutor, propertyId)
     }
 
@@ -143,9 +149,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param reservationId The unique identifier of the reservation.
      * @return A [GetSandboxReservationResponse] containing the requested reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun getReservation(reservationId: String) = run {
+    fun getReservation(reservationId: String): GetSandboxReservationResponse = run {
         getSandboxReservationOperation(graphQLExecutor, reservationId)
     }
 
@@ -153,9 +159,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      * Creates a new sandbox property with default name.
      *
      * @return A [CreateSandboxPropertyResponse] containing the created sandbox property data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun createProperty() = run {
+    fun createProperty(): CreateSandboxPropertyResponse = run {
         createSandboxPropertyOperation(graphQLExecutor, CreatePropertyInput())
     }
 
@@ -164,9 +170,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [CreatePropertyInput] specifying the details of the property to be created.
      * @return A [CreateSandboxPropertyResponse] containing the created sandbox property data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun createProperty(input: CreatePropertyInput) = run {
+    fun createProperty(input: CreatePropertyInput): CreateSandboxPropertyResponse = run {
         createSandboxPropertyOperation(graphQLExecutor, input)
     }
 
@@ -175,9 +181,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [UpdatePropertyInput] containing the updated property details.
      * @return An [UpdateSandboxPropertyResponse] containing the updated sandbox property data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun updateProperty(input: UpdatePropertyInput) = run {
+    fun updateProperty(input: UpdatePropertyInput): UpdateSandboxPropertyResponse = run {
         updateSandboxPropertyOperation(graphQLExecutor, input)
     }
 
@@ -186,9 +192,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param propertyId The unique identifier of the property to be deleted.
      * @return A [DeleteSandboxPropertyResponse] containing the deleted property data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun deleteProperty(propertyId: String) = run {
+    fun deleteProperty(propertyId: String): DeleteSandboxPropertyResponse = run {
         deleteSandboxPropertyOperation(graphQLExecutor, DeletePropertyInput(id = propertyId))
     }
 
@@ -197,9 +203,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param propertyId The unique identifier of the property.
      * @return A [CreateSandboxReservationResponse] containing the created reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun createReservation(propertyId: String) = run {
+    fun createReservation(propertyId: String): CreateSandboxReservationResponse = run {
         createSandboxReservationOperation(graphQLExecutor, CreateReservationInput(propertyId = propertyId))
     }
 
@@ -208,9 +214,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [CreateReservationInput] containing the reservation details.
      * @return A [CreateSandboxReservationResponse] containing the created reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun createReservation(input: CreateReservationInput) = run {
+    fun createReservation(input: CreateReservationInput): CreateSandboxReservationResponse = run {
         createSandboxReservationOperation(graphQLExecutor, input)
     }
 
@@ -219,9 +225,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [UpdateReservationInput] with the updated reservation details.
      * @return An [UpdateSandboxReservationResponse] containing the updated reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun updateReservation(input: UpdateReservationInput) = run {
+    fun updateReservation(input: UpdateReservationInput): UpdateSandboxReservationResponse = run {
         updateSandboxReservationOperation(graphQLExecutor, input)
     }
 
@@ -230,9 +236,11 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [ChangeReservationStayDatesInput] specifying the new stay dates.
      * @return A [ChangeSandboxReservationStayDatesResponse] containing the updated reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun changeReservationStayDates(input: ChangeReservationStayDatesInput) = run {
+    fun changeReservationStayDates(
+        input: ChangeReservationStayDatesInput
+    ): ChangeSandboxReservationStayDatesResponse = run {
         changeSandboxReservationStayDatesOperation(graphQLExecutor, input)
     }
 
@@ -241,9 +249,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param reservationId The unique identifier of the reservation to be canceled.
      * @return A [CancelSandboxReservationResponse] containing the canceled reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun cancelReservation(reservationId: String) = run {
+    fun cancelReservation(reservationId: String): CancelSandboxReservationResponse = run {
         cancelSandboxReservationOperation(graphQLExecutor, CancelReservationInput(id = reservationId))
     }
 
@@ -252,9 +260,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [CancelReservationInput] containing reservation details for cancellation.
      * @return A [CancelSandboxReservationResponse] containing the canceled reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun cancelReservation(input: CancelReservationInput) = run {
+    fun cancelReservation(input: CancelReservationInput): CancelSandboxReservationResponse = run {
         cancelSandboxReservationOperation(graphQLExecutor, input)
     }
 
@@ -263,9 +271,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param reservationId The unique identifier of the reservation to be deleted.
      * @return A [DeleteSandboxReservationResponse] containing the deleted reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun deleteReservation(reservationId: String) = run {
+    fun deleteReservation(reservationId: String): DeleteSandboxReservationResponse = run {
         deleteSandboxReservationOperation(graphQLExecutor, DeleteReservationInput(id = reservationId))
     }
 
@@ -274,9 +282,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [DeleteReservationInput] specifying the reservation to delete.
      * @return A [DeleteSandboxReservationResponse] containing the deleted reservation data and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun deleteReservation(input: DeleteReservationInput) = run {
+    fun deleteReservation(input: DeleteReservationInput): DeleteSandboxReservationResponse = run {
         deleteSandboxReservationOperation(graphQLExecutor, input)
     }
 
@@ -285,9 +293,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param propertyId The unique identifier of the property.
      * @return A [DeleteSandboxReservationsResponse] containing data for the deleted reservations and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun deleteReservations(propertyId: String) = run {
+    fun deleteReservations(propertyId: String): DeleteSandboxReservationsResponse = run {
         deleteSandboxReservationsOperation(
             graphQLExecutor,
             DeletePropertyReservationsInput(propertyId = propertyId)
@@ -299,9 +307,9 @@ class SandboxDataManagementClient(config: ClientConfiguration) : GraphQLClient()
      *
      * @param input The [DeletePropertyReservationsInput] specifying the reservations to delete.
      * @return A [DeleteSandboxReservationsResponse] containing data for the deleted reservations and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
-    fun deleteReservations(input: DeletePropertyReservationsInput) = run {
+    fun deleteReservations(input: DeletePropertyReservationsInput): DeleteSandboxReservationsResponse = run {
         deleteSandboxReservationsOperation(graphQLExecutor, input)
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/CreateSandboxPropertyOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/CreateSandboxPropertyOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.property.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -44,7 +45,7 @@ data class CreateSandboxPropertyResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [CreatePropertyInput] containing the details for the property to be created.
  * @return A [CreateSandboxPropertyResponse] containing the created sandbox property data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun createSandboxPropertyOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/DeleteSandboxPropertyOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/DeleteSandboxPropertyOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.property.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -44,7 +45,7 @@ data class DeleteSandboxPropertyResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [DeletePropertyInput] containing the details of the property to be deleted.
  * @return A [DeleteSandboxPropertyResponse] containing the deleted property data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun deleteSandboxPropertyOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/GetSandboxPropertiesOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/GetSandboxPropertiesOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.property.operation
 
 import com.expediagroup.sdk.core.extension.orNullIfBlank
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.paging.PageInfo
 import com.expediagroup.sdk.graphql.model.response.PaginatedResponse
@@ -51,7 +52,7 @@ data class GetSandboxPropertiesResponse(
  * @param cursor An optional cursor to specify the starting point for pagination; defaults to `null` for the first page.
  * @param pageSize The number of properties to retrieve per page; defaults to `null` to use the server's default page size.
  * @return A [GetSandboxPropertiesResponse] containing the sandbox properties data, pagination information, and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
  */
 @JvmOverloads
 fun getSandboxPropertiesOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/GetSandboxPropertyOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/GetSandboxPropertyOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.property.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -45,7 +46,7 @@ data class GetSandboxPropertyResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL query.
  * @param propertyId The unique identifier of the sandbox property to retrieve.
  * @return A [GetSandboxPropertyResponse] containing the requested sandbox property data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
  */
 fun getSandboxPropertyOperation(graphQLExecutor: GraphQLExecutor, propertyId: String): GetSandboxPropertyResponse {
     val operation = SandboxPropertyQuery(propertyId)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/UpdateSandboxPropertyOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/property/operation/UpdateSandboxPropertyOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.property.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -46,7 +47,7 @@ data class UpdateSandboxPropertyResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [UpdatePropertyInput] containing the details of the property update.
  * @return An [UpdateSandboxPropertyResponse] containing the updated sandbox property data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun updateSandboxPropertyOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/CancelSandboxReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/CancelSandboxReservationOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -46,7 +47,7 @@ data class CancelSandboxReservationResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [CancelReservationInput] containing the details of the reservation to be canceled.
  * @return A [CancelSandboxReservationResponse] containing the canceled reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun cancelSandboxReservationOperation(graphQLExecutor: GraphQLExecutor, input: CancelReservationInput): CancelSandboxReservationResponse {
     val operation = SandboxCancelReservationMutation(input)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/ChangeSandboxReservationStayDatesOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/ChangeSandboxReservationStayDatesOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -46,7 +47,7 @@ data class ChangeSandboxReservationStayDatesResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [ChangeReservationStayDatesInput] containing the new stay dates for the reservation.
  * @return A [ChangeSandboxReservationStayDatesResponse] containing the updated reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun changeSandboxReservationStayDatesOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/CreateSandboxReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/CreateSandboxReservationOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -44,7 +45,7 @@ data class CreateSandboxReservationResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [CreateReservationInput] containing the details for the new reservation.
  * @return A [CreateSandboxReservationResponse] containing the created reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun createSandboxReservationOperation(graphQLExecutor: GraphQLExecutor, input: CreateReservationInput): CreateSandboxReservationResponse {
     val operation = SandboxCreateReservationMutation(input)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/DeleteSandboxReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/DeleteSandboxReservationOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -44,7 +45,7 @@ data class DeleteSandboxReservationResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [DeleteReservationInput] containing the details of the reservation to be deleted.
  * @return A [DeleteSandboxReservationResponse] containing the deleted reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun deleteSandboxReservationOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/DeleteSandboxReservationsOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/DeleteSandboxReservationsOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -44,7 +45,7 @@ data class DeleteSandboxReservationsResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [DeletePropertyReservationsInput] containing the details of the reservations to be deleted.
  * @return A [DeleteSandboxReservationsResponse] containing data for the deleted reservations and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun deleteSandboxReservationsOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/GetSandboxReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/GetSandboxReservationOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -43,7 +44,7 @@ data class GetSandboxReservationResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL query.
  * @param reservationId The unique identifier of the sandbox reservation to retrieve.
  * @return A [GetSandboxReservationResponse] containing the requested reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
  */
 fun getSandboxReservationOperation(graphQLExecutor: GraphQLExecutor, reservationId: String): GetSandboxReservationResponse {
     val operation = SandboxReservationQuery(reservationId)

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/GetSandboxReservationsOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/GetSandboxReservationsOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orNullIfBlank
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.paging.PageInfo
 import com.expediagroup.sdk.graphql.model.response.PaginatedResponse
@@ -50,7 +51,7 @@ data class GetSandboxReservationsResponse(
  * @param cursor An optional cursor to specify the starting point for pagination; defaults to `null` for the first page.
  * @param pageSize The number of reservations to retrieve per page; defaults to `null` to use the server's default page size.
  * @return A [GetSandboxReservationsResponse] containing the sandbox reservations data, pagination information, and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
  */
 @JvmOverloads
 fun getSandboxReservationsOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/UpdateSandboxReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/operation/UpdateSandboxReservationOperation.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.operation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -45,7 +46,7 @@ data class UpdateSandboxReservationResponse(
  * @param graphQLExecutor The [GraphQLExecutor] responsible for executing the GraphQL mutation.
  * @param input The [UpdateReservationInput] containing the new details for the reservation.
  * @return An [UpdateSandboxReservationResponse] containing the updated reservation data and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 fun updateSandboxReservationOperation(
     graphQLExecutor: GraphQLExecutor,

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/paginator/SandboxReservationsPaginator.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/sandbox/reservation/paginator/SandboxReservationsPaginator.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.sandbox.reservation.paginator
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.paging.PageInfo
 import com.expediagroup.sdk.graphql.model.response.PaginatedResponse
@@ -88,7 +89,7 @@ class SandboxReservationsPaginator @JvmOverloads constructor(
      *
      * @return A [SandboxReservationsPaginatedResponse] containing the sandbox reservations, raw response, and pagination details.
      * @throws NoSuchElementException If no more pages are available to fetch.
-     * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
      */
     override fun next(): SandboxReservationsPaginatedResponse {
         if (!hasNext()) {

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/ReservationClient.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/ReservationClient.kt
@@ -16,6 +16,7 @@
 
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation
 
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.DefaultGraphQLExecutor
 import com.expediagroup.sdk.graphql.common.GraphQLClient
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
@@ -82,7 +83,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
         selections: ReservationSelections? = null,
         pageSize: Int? = null,
         initialCursor: String? = null
-    ) = run {
+    ): ReservationsPaginator = run {
         ReservationsPaginator(
             graphQLExecutor = graphQLExecutor,
             input = PropertyReservationsInput(propertyId),
@@ -105,7 +106,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
         propertyId: String,
         pageSize: Int,
         initialCursor: String? = null
-    ) = run {
+    ): ReservationsPaginator = run {
         ReservationsPaginator(
             graphQLExecutor = graphQLExecutor,
             input = PropertyReservationsInput(propertyId),
@@ -129,7 +130,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
         selections: ReservationSelections? = null,
         pageSize: Int? = null,
         initialCursor: String? = null
-    ) = run {
+    ): ReservationsPaginator = run {
         ReservationsPaginator(
             graphQLExecutor = graphQLExecutor,
             input = input,
@@ -152,7 +153,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
         input: PropertyReservationsInput,
         pageSize: Int,
         initialCursor: String? = null
-    ) = run {
+    ): ReservationsPaginator = run {
         ReservationsPaginator(
             graphQLExecutor = graphQLExecutor,
             input = input,
@@ -167,7 +168,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param propertyId The unique identifier of the property.
      * @return A [ReservationsStream] to stream through reservations one at a time.
      */
-    fun getReservationsStream(propertyId: String) = run {
+    fun getReservationsStream(propertyId: String): ReservationsStream = run {
         ReservationsStream(getReservationsPaginator(propertyId))
     }
 
@@ -177,7 +178,7 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [PropertyReservationsInput] specifying the property and filter criteria.
      * @return A [ReservationsStream] to stream through reservations one at a time.
      */
-    fun getReservationsStream(input: PropertyReservationsInput) = run {
+    fun getReservationsStream(input: PropertyReservationsInput): ReservationsStream = run {
         ReservationsStream(getReservationsPaginator(input))
     }
 
@@ -187,13 +188,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [CancelReservationInput] containing the details of the reservation to be canceled.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [CancelReservationResponse] containing the canceled reservation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun cancelReservation(
         input: CancelReservationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): CancelReservationResponse = run {
         cancelReservationOperation(graphQLExecutor, input, selections)
     }
 
@@ -203,13 +204,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [CancelReservationReconciliationInput] containing the details of the reservation reconciliation to be canceled.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [CancelReservationReconciliationResponse] containing the canceled reconciliation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun cancelReservationReconciliation(
         input: CancelReservationReconciliationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): CancelReservationReconciliationResponse = run {
         cancelReservationReconciliationOperation(graphQLExecutor, input, selections)
     }
 
@@ -219,13 +220,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [CancelVrboReservationInput] containing the details of the VRBO reservation to be canceled.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [CancelVrboReservationResponse] containing the canceled reservation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun cancelVrboReservation(
         input: CancelVrboReservationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): CancelVrboReservationResponse = run {
         cancelVrboReservationOperation(graphQLExecutor, input, selections)
     }
 
@@ -235,13 +236,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [ChangeReservationReconciliationInput] containing the new reconciliation details for the reservation.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [ChangeReservationReconciliationResponse] containing the updated reconciliation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun changeReservationReconciliation(
         input: ChangeReservationReconciliationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): ChangeReservationReconciliationResponse = run {
         changeReservationReconciliationOperation(graphQLExecutor, input, selections)
     }
 
@@ -251,13 +252,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [ConfirmReservationNotificationInput] containing the details of the reservation notification to confirm.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [ConfirmReservationNotificationResponse] containing the confirmed reservation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun confirmReservationNotification(
         input: ConfirmReservationNotificationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): ConfirmReservationNotificationResponse = run {
         confirmReservationNotificationOperation(graphQLExecutor, input, selections)
     }
 
@@ -267,13 +268,13 @@ class ReservationClient(config: ClientConfiguration) : GraphQLClient() {
      * @param input The [RefundReservationInput] containing the details of the reservation to be refunded.
      * @param selections An optional [ReservationSelections] specifying additional fields to include in the response.
      * @return A [RefundReservationResponse] containing the refunded reservation data (if available) and the full raw response.
-     * @throws ExpediaGroupServiceException If an error occurs during the operation execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the operation execution.
      */
     @JvmOverloads
     fun refundReservation(
         input: RefundReservationInput,
         selections: ReservationSelections? = null
-    ) = run {
+    ): RefundReservationResponse = run {
         refundReservationOperation(graphQLExecutor, input, selections)
     }
 }

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelReservationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class CancelReservationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [CancelReservationResponse] containing the canceled reservation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun cancelReservationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelReservationReconciliationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelReservationReconciliationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class CancelReservationReconciliationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [CancelReservationReconciliationResponse] containing the canceled reconciliation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun cancelReservationReconciliationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelVrboReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/CancelVrboReservationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class CancelVrboReservationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [CancelVrboReservationResponse] containing the canceled reservation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun cancelVrboReservationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/ChangeReservationReconciliationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/ChangeReservationReconciliationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class ChangeReservationReconciliationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [ChangeReservationReconciliationResponse] containing the updated reconciliation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun changeReservationReconciliationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/ConfirmReservationNotificationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/ConfirmReservationNotificationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class ConfirmReservationNotificationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [ConfirmReservationNotificationResponse] containing the confirmed reservation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun confirmReservationNotificationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/GetReservationsOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/GetReservationsOperation.kt
@@ -59,7 +59,7 @@ data class PropertyReservationsResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response,
  * such as supplier amount and payment instrument token; defaults to `null`.
  * @return A [PropertyReservationsResponse] containing the reservation data, pagination information, and the full raw response.
- * @throws ExpediaGroupServiceException If the property data is not available in the response.
+ * @throws [ExpediaGroupServiceException] If the property data is not available in the response.
  */
 @JvmOverloads
 fun getReservationsOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/RefundReservationOperation.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/operation/RefundReservationOperation.kt
@@ -17,6 +17,7 @@
 package com.expediagroup.sdk.lodgingconnectivity.supply.reservation.operation
 
 import com.expediagroup.sdk.core.extension.orFalseIfNull
+import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.graphql.common.GraphQLExecutor
 import com.expediagroup.sdk.graphql.model.response.RawResponse
 import com.expediagroup.sdk.graphql.model.response.Response
@@ -50,7 +51,7 @@ data class RefundReservationResponse(
  * @param selections An optional [ReservationSelections] specifying additional fields to include in the response, such as
  * supplier amount and payment instrument token; defaults to `null`.
  * @return A [RefundReservationResponse] containing the refunded reservation data (if available) and the full raw response.
- * @throws ExpediaGroupServiceException If an error occurs during the mutation execution.
+ * @throws [ExpediaGroupServiceException] If an error occurs during the mutation execution.
  */
 @JvmOverloads
 fun refundReservationOperation(

--- a/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/paginator/ReservationsPaginator.kt
+++ b/code/src/main/kotlin/com/expediagroup/sdk/lodgingconnectivity/supply/reservation/paginator/ReservationsPaginator.kt
@@ -97,7 +97,7 @@ class ReservationsPaginator @JvmOverloads constructor(
      *
      * @return A [ReservationsPaginatedResponse] containing the property reservations, raw response, and pagination details.
      * @throws NoSuchElementException If no more pages are available to fetch.
-     * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
      */
     override fun next(): ReservationsPaginatedResponse {
         if (!hasNext()) {
@@ -126,7 +126,7 @@ class ReservationsPaginator @JvmOverloads constructor(
      * Checks if there are any reservations available to fetch, initializing the paginator if necessary.
      *
      * @return `true` if there are reservations available, `false` otherwise.
-     * @throws ExpediaGroupServiceException If an error occurs during the query execution.
+     * @throws [ExpediaGroupServiceException] If an error occurs during the query execution.
      */
     private fun hasReservationsToFetch(): Boolean = run {
         graphQLExecutor.execute(


### PR DESCRIPTION
# Summary
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->

1. We have some classes and functions that contain unnecessary `@Throws` annotation, as these thrown exceptions are runtime exceptions and no need to force Java users to treat them as checked exceptions.

2. Converted some HTTP model classes to `data` classes with `@ConsistentCopyVisibility` annotation. This annotation forces the `copy` method to inherit the constructor visibility and surpasses IntelliJ warning about using data classes with private constructor.

3. Added explicit return types for the named methods in LC clients.