### PR TITLE
fix: update tests to use new naming for request executor

### DIFF
--- a/code/src/test/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManagerTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManagerTest.kt
@@ -18,8 +18,11 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows

--- a/code/src/test/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManagerTest.kt
+++ b/code/src/test/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManagerTest.kt
@@ -1,7 +1,7 @@
 package com.expediagroup.sdk.core.authentication.bearer
 
 import com.expediagroup.sdk.core.authentication.common.Credentials
-import com.expediagroup.sdk.core.client.RequestExecutor
+import com.expediagroup.sdk.core.client.AbstractRequestExecutor
 import com.expediagroup.sdk.core.http.CommonMediaTypes
 import com.expediagroup.sdk.core.http.Method
 import com.expediagroup.sdk.core.http.Protocol
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BearerAuthenticationManagerTest {
 
-    private lateinit var requestExecutor: RequestExecutor
+    private lateinit var requestExecutor: AbstractRequestExecutor
     private lateinit var credentials: Credentials
     private lateinit var authenticationManager: BearerAuthenticationManager
     private val authUrl = "http://auth.example.com/token"


### PR DESCRIPTION
# Situation
In pull-request #141, `RequestExecutor` class was renamed to `AbstractRequestExecutor`. This change broke tests that were merged in pull request #128.

# Task
Update `RequestExecutor` usages to `AbstractRequestExecutor`.

# Action
Renamed `RequestExecutor` to `AbstractRequestExecutor` in the following files:
* `code/src/test/kotlin/com/expediagroup/sdk/core/authentication/bearer/BearerAuthenticationManagerTest.kt`

# Testing
**Not needed.**

# Results
Tests now are compiling and passing as expected.

# Notes
**NaN**