### PR TITLE
chore: init rest module

### DIFF
--- a/expediagroup-sdk-rest/build.gradle
+++ b/expediagroup-sdk-rest/build.gradle
@@ -1,0 +1,61 @@
+import kotlinx.kover.gradle.plugin.dsl.AggregationType
+import kotlinx.kover.gradle.plugin.dsl.CoverageUnit
+
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '2.1.0'
+
+    /* Test Reporting */
+    id 'org.jetbrains.kotlinx.kover' version "0.9.1"
+}
+
+kotlin {
+    jvmToolchain(8)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    /* Kotlin */
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:2.1.0'
+
+    /* EG SDK Core */
+    api(project(":expediagroup-sdk-core"))
+
+    /* Testing */
+    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation 'io.mockk:mockk:1.13.14'
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}
+
+kover {
+    reports {
+        total {
+            verify {
+                rule {
+                    bound {
+                        aggregationForGroup = AggregationType.COVERED_PERCENTAGE
+                        coverageUnits = CoverageUnit.LINE
+                        minValue = 100
+                    }
+                    bound {
+                        aggregationForGroup = AggregationType.COVERED_PERCENTAGE
+                        coverageUnits = CoverageUnit.BRANCH
+                        minValue = 92
+                    }
+                }
+            }
+        }
+    }
+}

--- a/expediagroup-sdk-rest/build.gradle
+++ b/expediagroup-sdk-rest/build.gradle
@@ -52,7 +52,7 @@ kover {
                     bound {
                         aggregationForGroup = AggregationType.COVERED_PERCENTAGE
                         coverageUnits = CoverageUnit.BRANCH
-                        minValue = 92
+                        minValue = 100
                     }
                 }
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,5 @@ include 'apollo-compiler-plugin'
 include 'expediagroup-sdk-core'
 include 'expediagroup-sdk-okhttp-transport'
 include 'expediagroup-sdk-graphql'
+include 'expediagroup-sdk-rest'
+


### PR DESCRIPTION
# Situation
As per our latest architecture design decisions, we decided to add a separate extension module for **REST APIs-based SDKs**. The rest sdk extension package provides contracts and utilities that augment the core SDK with essential capabilities for REST API interactions, enabling seamless consumption of HTTP-based endpoints.

By abstracting complexities around request construction, response parsing, and error handling, this extension provides a production-ready and scalable foundation that can be tailored to specific product SDKs.

# Task
Initialize a new `expediagroup-sdk-rest` module.

# Action
* Initialized new the module.
* Included the module in the project's 'settings.gradle'.
* Configured the module's `build.gradle` file to match our standards with:
    * `100%` code coverage validation.
    * Code coverage reports.
    * Added needed dependencies. 

# Testing
**NaN**

# Results
New module `expediagroup-sdk-rest` initialized.

# Notes
**NaN**