### PR TITLE
chore: support for openapi query param formats

### DIFF
--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParam.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParam.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.sdk.rest.model
 
 import com.expediagroup.sdk.rest.util.StringifyQueryParam
@@ -14,6 +30,10 @@ data class UrlQueryParam(
     val value: List<String>,
     val stringify: StringifyQueryParam
 ) {
+    init {
+        require(key.isNotBlank()) { "Query parameter key cannot be blank!" }
+    }
+
     /**
      * Converts the query parameter to a string using the provided stringifier.
      *

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParam.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParam.kt
@@ -1,0 +1,23 @@
+package com.expediagroup.sdk.rest.model
+
+import com.expediagroup.sdk.rest.util.StringifyQueryParam
+
+/**
+ * Data class representing a URL query parameter.
+ *
+ * @property key The key of the query parameter.
+ * @property value The list of values associated with the query parameter.
+ * @property stringify The stringifier used to convert the query parameter to a string.
+ */
+data class UrlQueryParam(
+    val key: String,
+    val value: List<String>,
+    val stringify: StringifyQueryParam
+) {
+    /**
+     * Converts the query parameter to a string using the provided stringifier.
+     *
+     * @return The string representation of the query parameter.
+     */
+    override fun toString(): String = stringify(this)
+}

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2025 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.expediagroup.sdk.rest.util
 
 import com.expediagroup.sdk.rest.model.UrlQueryParam

--- a/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
+++ b/expediagroup-sdk-rest/src/main/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtils.kt
@@ -1,0 +1,60 @@
+package com.expediagroup.sdk.rest.util
+
+import com.expediagroup.sdk.rest.model.UrlQueryParam
+
+/**
+ * Functional interface for converting a UrlQueryParam to a String.
+ */
+fun interface StringifyQueryParam : (UrlQueryParam) -> String {
+    /**
+     * Converts the given UrlQueryParam to a String.
+     *
+     * @param queryParam the UrlQueryParam to convert
+     * @return the String representation of the UrlQueryParam
+     */
+    override fun invoke(queryParam: UrlQueryParam): String
+}
+
+/**
+ * Converts a UrlQueryParam to a form-encoded String.
+ * Example: key=value1,value2
+ */
+val stringifyForm = StringifyQueryParam { param ->
+    StringBuilder().apply {
+        append("${param.key}=")
+        append(param.value.joinToString(","))
+    }.toString()
+}
+
+/**
+ * Converts a UrlQueryParam to an exploded form-encoded String.
+ * Example: key=value1&key=value2
+ */
+val stringifyExplode = StringifyQueryParam { param ->
+    StringBuilder().apply {
+        append("${param.key}=")
+        append(param.value.joinToString("&${param.key}="))
+    }.toString()
+}
+
+/**
+ * Converts a UrlQueryParam to a space-delimited String.
+ * Example: key=value1%20value2
+ */
+val stringifySpaceDelimited = StringifyQueryParam { param ->
+    StringBuilder().apply {
+        append("${param.key}=")
+        append(param.value.joinToString("%20"))
+    }.toString()
+}
+
+/**
+ * Converts a UrlQueryParam to a pipe-delimited String.
+ * Example: key=value1|value2
+ */
+val stringifyPipeDelimited = StringifyQueryParam { param ->
+    StringBuilder().apply {
+        append("${param.key}=")
+        append(param.value.joinToString("|"))
+    }.toString()
+}

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
@@ -37,17 +37,6 @@ class UrlQueryParamTest {
     }
 
     @Test
-    fun `converts to string with empty values`() {
-        val mockStringify = mockk<StringifyQueryParam>()
-        val param = UrlQueryParam("key", emptyList(), mockStringify)
-        every { mockStringify.invoke(param) } returns "key="
-
-        val result = param.toString()
-
-        assertEquals("key=", result)
-    }
-
-    @Test
     fun `throws IllegalArgumentException exception null key`() {
         val mockStringify = mockk<StringifyQueryParam>()
         val exception = assertThrows<IllegalArgumentException> {

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class UrlQueryParamTest {
     @Test
@@ -47,24 +48,12 @@ class UrlQueryParamTest {
     }
 
     @Test
-    fun `converts to string with special characters`() {
+    fun `throws IllegalArgumentException exception null key`() {
         val mockStringify = mockk<StringifyQueryParam>()
-        val param = UrlQueryParam("key", listOf("value1", "value&2"), mockStringify)
-        every { mockStringify.invoke(param) } returns "key=value1,value%262"
+        val exception = assertThrows<IllegalArgumentException> {
+            UrlQueryParam("", listOf("value1", "value2"), mockStringify)
+        }
 
-        val result = param.toString()
-
-        assertEquals("key=value1,value%262", result)
-    }
-
-    @Test
-    fun `converts to string with null key`() {
-        val mockStringify = mockk<StringifyQueryParam>()
-        val param = UrlQueryParam("", listOf("value1", "value2"), mockStringify)
-        every { mockStringify.invoke(param) } returns "=value1,value2"
-
-        val result = param.toString()
-
-        assertEquals("=value1,value2", result)
+        assertEquals("Query parameter key cannot be blank!", exception.message)
     }
 }

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/model/UrlQueryParamTest.kt
@@ -1,0 +1,70 @@
+package com.expediagroup.sdk.rest.model
+
+import com.expediagroup.sdk.rest.util.StringifyQueryParam
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UrlQueryParamTest {
+    @Test
+    fun `does not mutate values on initialization`() {
+        val stringifyMock = mockk<StringifyQueryParam>()
+        val params = mapOf(
+            "key1" to listOf("value1", "value2"),
+            "key2" to listOf("value3", "value4")
+        )
+
+        params.forEach { (key, value) ->
+            val queryParam = UrlQueryParam(key, value, stringifyMock)
+
+            assertEquals(key, queryParam.key)
+            assertEquals(value, queryParam.value)
+            assertEquals(stringifyMock, queryParam.stringify)
+        }
+    }
+
+    @Test
+    fun `converts to string using stringifier`() {
+        val mockStringify = mockk<StringifyQueryParam>()
+        val param = UrlQueryParam("key", listOf("value1", "value2"), mockStringify)
+        every { mockStringify.invoke(param) } returns "key=value1,value2"
+
+        val result = param.toString()
+
+        assertEquals("key=value1,value2", result)
+    }
+
+    @Test
+    fun `converts to string with empty values`() {
+        val mockStringify = mockk<StringifyQueryParam>()
+        val param = UrlQueryParam("key", emptyList(), mockStringify)
+        every { mockStringify.invoke(param) } returns "key="
+
+        val result = param.toString()
+
+        assertEquals("key=", result)
+    }
+
+    @Test
+    fun `converts to string with special characters`() {
+        val mockStringify = mockk<StringifyQueryParam>()
+        val param = UrlQueryParam("key", listOf("value1", "value&2"), mockStringify)
+        every { mockStringify.invoke(param) } returns "key=value1,value%262"
+
+        val result = param.toString()
+
+        assertEquals("key=value1,value%262", result)
+    }
+
+    @Test
+    fun `converts to string with null key`() {
+        val mockStringify = mockk<StringifyQueryParam>()
+        val param = UrlQueryParam("", listOf("value1", "value2"), mockStringify)
+        every { mockStringify.invoke(param) } returns "=value1,value2"
+
+        val result = param.toString()
+
+        assertEquals("=value1,value2", result)
+    }
+}

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
@@ -2,7 +2,6 @@ package com.expediagroup.sdk.rest.util
 
 import com.expediagroup.sdk.rest.model.UrlQueryParam
 import io.mockk.mockk
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
@@ -11,357 +10,57 @@ class UrlQueryParamUtilsTest {
         val stringifyQueryParam = mockk<StringifyQueryParam>()
     }
 
-    @Nested
-    inner class StringifyFormTest {
-        @Test
-        fun `should return form-encoded string for single value`() {
-            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
-            val expected = "key1=value1"
-            assertEquals(expected, stringifyForm(param))
+    @Test
+    fun `invoke should correctly convert UrlQueryParam to String using provided logic`() {
+        val customStringify = StringifyQueryParam { param ->
+            "${param.key}:${param.value.joinToString("-")}"
         }
 
-        @Test
-        fun `should return form-encoded string for multiple values`() {
-            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
-            val expected = "key1=value1,value2,value3"
-            assertEquals(expected, stringifyForm(param))
-        }
+        val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyQueryParam)
+        val expectedString = "myKey:v1-v2"
 
-        @Test
-        fun `should return form-encoded string for empty value list`() {
-            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
-            val expected = "key1="
-            assertEquals(expected, stringifyForm(param))
-        }
+        val actualString = customStringify(param)
 
-        @Test
-        fun `should return form-encoded string for key with special characters`() {
-            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
-            val expected = "key with spaces=value1"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should return form-encoded string for values with special characters`() {
-            val param = UrlQueryParam("key1", listOf("value with,comma", "value with&ampersand", "value with=equals"), stringifyQueryParam)
-            val expected = "key1=value with,comma,value with&ampersand,value with=equals"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should return form-encoded string for values with plus sign`() {
-            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
-            val expected = "key1=value+with+plus"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should return form-encoded string for values with forward slash`() {
-            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
-            val expected = "key1=value/with/slash"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should handle very long key`() {
-            val longKey = "a".repeat(1024)
-            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
-            val expected = "${longKey}=value1"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should handle very long value`() {
-            val longValue = "b".repeat(1024)
-            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
-            val expected = "key1=${longValue}"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should handle very large number of values`() {
-            val values = List(1000) { "value$it" }
-            val param = UrlQueryParam("key1", values, stringifyQueryParam)
-            val expected = "key1=" + values.joinToString(",")
-            assertEquals(expected, stringifyForm(param))
-        }
+        assertEquals(expectedString, actualString)
     }
 
-    @Nested
-    inner class StringifyExplodeTest {
-        @Test
-        fun `should return exploded form-encoded string for single value`() {
-            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
-            val expected = "key1=value1"
-            assertEquals(expected, stringifyExplode(param))
-        }
+    @Test
+    fun `stringifyForm should correctly convert UrlQueryParam to form-encoded String`() {
+        val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyForm)
+        val expectedString = "myKey=v1,v2"
 
-        @Test
-        fun `should return exploded form-encoded string for multiple values`() {
-            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
-            val expected = "key1=value1&key1=value2&key1=value3"
-            assertEquals(expected, stringifyExplode(param))
-        }
+        val actualString = stringifyForm(param)
 
-        @Test
-        fun `should return exploded form-encoded string for empty value list`() {
-            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
-            val expected = "key1="
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should return exploded form-encoded string for key with special characters`() {
-            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
-            val expected = "key with spaces=value1"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should return exploded form-encoded string for values with special characters`() {
-            val param = UrlQueryParam("key1", listOf("value with,comma", "value with&ampersand", "value with=equals"), stringifyQueryParam)
-            val expected = "key1=value with,comma&key1=value with&ampersand&key1=value with=equals"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should return exploded form-encoded string for values with plus sign`() {
-            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
-            val expected = "key1=value+with+plus"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should return exploded form-encoded string for values with forward slash`() {
-            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
-            val expected = "key1=value/with/slash"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should handle very long key in exploded form`() {
-            val longKey = "a".repeat(1024)
-            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
-            val expected = "${longKey}=value1"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should handle very long value in exploded form`() {
-            val longValue = "b".repeat(1024)
-            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
-            val expected = "key1=${longValue}"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
-        fun `should handle very large number of values in exploded form`() {
-            val values = List(1000) { "value$it" }
-            val param = UrlQueryParam("key1", values, stringifyQueryParam)
-            val expected = values.joinToString("&key1=", prefix = "key1=")
-            assertEquals(expected, stringifyExplode(param))
-        }
+        assertEquals(expectedString, actualString)
     }
 
-    @Nested
-    inner class StringifySpaceDelimitedTest {
-        @Test
-        fun `should return space-delimited string for single value`() {
-            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
-            val expected = "key1=value1"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
+    @Test
+    fun `stringifyExplode should correctly convert UrlQueryParam to exploded form-encoded String`() {
+        val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyExplode)
+        val expectedString = "myKey=v1&myKey=v2"
 
-        @Test
-        fun `should return space-delimited string for multiple values`() {
-            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
-            val expected = "key1=value1%20value2%20value3"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
+        val actualString = stringifyExplode(param)
 
-        @Test
-        fun `should return space-delimited string for empty value list`() {
-            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
-            val expected = "key1="
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should return space-delimited string for key with special characters`() {
-            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
-            val expected = "key with spaces=value1"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should return space-delimited string for values with special characters`() {
-            val param = UrlQueryParam("key1", listOf("value with space", "value2"), stringifyQueryParam)
-            val expected = "key1=value with space%20value2"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should return space-delimited string for values with plus sign`() {
-            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
-            val expected = "key1=value+with+plus"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should return space-delimited string for values with forward slash`() {
-            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
-            val expected = "key1=value/with/slash"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should handle very long key in space delimited form`() {
-            val longKey = "a".repeat(1024)
-            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
-            val expected = "${longKey}=value1"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should handle very long value in space delimited form`() {
-            val longValue = "b".repeat(1024)
-            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
-            val expected = "key1=${longValue}"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should handle very large number of values in space delimited form`() {
-            val values = List(1000) { "value$it" }
-            val param = UrlQueryParam("key1", values, stringifyQueryParam)
-            val expected = "key1=" + values.joinToString("%20")
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
+        assertEquals(expectedString, actualString)
     }
 
-    @Nested
-    inner class StringifyPipeDelimitedTest {
-        @Test
-        fun `should return pipe-delimited string for single value`() {
-            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
-            val expected = "key1=value1"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
+    @Test
+    fun `stringifySpaceDelimited should correctly convert UrlQueryParam to space-delimited String`() {
+        val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifySpaceDelimited)
+        val expectedString = "myKey=v1%20v2"
 
-        @Test
-        fun `should return pipe-delimited string for multiple values`() {
-            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
-            val expected = "key1=value1|value2|value3"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
+        val actualString = stringifySpaceDelimited(param)
 
-        @Test
-        fun `should return pipe-delimited string for empty value list`() {
-            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
-            val expected = "key1="
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should return pipe-delimited string for key with special characters`() {
-            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
-            val expected = "key with spaces=value1"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should return pipe-delimited string for values with special characters`() {
-            val param = UrlQueryParam("key1", listOf("value with|pipe", "value2"), stringifyQueryParam)
-            val expected = "key1=value with|pipe|value2"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should return pipe-delimited string for values with plus sign`() {
-            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
-            val expected = "key1=value+with+plus"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should return pipe-delimited string for values with forward slash`() {
-            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
-            val expected = "key1=value/with/slash"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should handle very long key in pipe delimited form`() {
-            val longKey = "a".repeat(1024)
-            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
-            val expected = "${longKey}=value1"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should handle very long value in pipe delimited form`() {
-            val longValue = "b".repeat(1024)
-            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
-            val expected = "key1=${longValue}"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
-        fun `should handle very large number of values in pipe delimited form`() {
-            val values = List(1000) { "value$it" }
-            val param = UrlQueryParam("key1", values, stringifyQueryParam)
-            val expected = "key1=" + values.joinToString("|")
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
+        assertEquals(expectedString, actualString)
     }
 
-    @Nested
-    inner class StringifyQueryParamTest {
-        @Test
-        fun `invoke should correctly convert UrlQueryParam to String using provided logic`() {
-            val customStringify = StringifyQueryParam { param ->
-                "${param.key}:${param.value.joinToString("-")}"
-            }
-            val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyQueryParam)
-            val expectedString = "myKey:v1-v2"
+    @Test
+    fun `stringifyPipeDelimited should correctly convert UrlQueryParam to pipe-delimited String`() {
+        val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyPipeDelimited)
+        val expectedString = "myKey=v1|v2"
 
-            val actualString = customStringify(param)
+        val actualString = stringifyPipeDelimited(param)
 
-            assertEquals(expectedString, actualString)
-        }
-
-        @Test
-        fun `invoke should handle empty values list`() {
-            val customStringify = StringifyQueryParam { param ->
-                "${param.key}:${param.value.joinToString("-")}"
-            }
-            val param = UrlQueryParam("myKey", emptyList(), stringifyQueryParam)
-            val expectedString = "myKey:"
-
-            val actualString = customStringify(param)
-
-            assertEquals(expectedString, actualString)
-        }
-
-        @Test
-        fun `invoke should handle custom encoding`() {
-            val customStringify = StringifyQueryParam { param ->
-                val encodedValues = param.value.map { it.replace(" ", "+") } // Encode space as +
-                "${param.key}=${encodedValues.joinToString(",")}"
-            }
-            val param = UrlQueryParam("key", listOf("value with space", "another value"), stringifyQueryParam)
-            val expected = "key=value+with+space,another+value"
-            assertEquals(expected, customStringify(param))
-        }
-
-        @Test
-        fun `invoke should add a prefix`() {
-            val customStringify = StringifyQueryParam { param ->
-                "prefix_${param.key}=${param.value.joinToString(",")}"
-            }
-            val param = UrlQueryParam("key", listOf("v1", "v2"), stringifyQueryParam)
-            val expected = "prefix_key=v1,v2"
-            assertEquals(expected, customStringify(param))
-        }
+        assertEquals(expectedString, actualString)
     }
 }

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
@@ -1,0 +1,408 @@
+package com.expediagroup.sdk.rest.util
+
+import com.expediagroup.sdk.rest.model.UrlQueryParam
+import io.mockk.mockk
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals // Import JUnit Jupiter Assertions
+
+class UrlQueryParamUtilsTest {
+    companion object {
+        val stringifyQueryParam = mockk<StringifyQueryParam>()
+    }
+
+    @Nested
+    inner class StringifyFormTest {
+        @Test
+        fun `should return form-encoded string for single value`() {
+            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
+            val expected = "key1=value1"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for multiple values`() {
+            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
+            val expected = "key1=value1,value2,value3"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for empty value list`() {
+            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
+            val expected = "key1="
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for key with special characters`() {
+            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
+            val expected = "key with spaces=value1"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for values with special characters`() {
+            val param = UrlQueryParam("key1", listOf("value with,comma", "value with&ampersand", "value with=equals"), stringifyQueryParam)
+            val expected = "key1=value with,comma,value with&ampersand,value with=equals"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for empty key`() {
+            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
+            val expected = "=value1,value2"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for values with plus sign`() {
+            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
+            val expected = "key1=value+with+plus"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should return form-encoded string for values with forward slash`() {
+            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
+            val expected = "key1=value/with/slash"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should handle very long key`() {
+            val longKey = "a".repeat(1024)
+            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
+            val expected = "${longKey}=value1"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should handle very long value`() {
+            val longValue = "b".repeat(1024)
+            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
+            val expected = "key1=${longValue}"
+            assertEquals(expected, stringifyForm(param))
+        }
+
+        @Test
+        fun `should handle very large number of values`() {
+            val values = List(1000) { "value$it" }
+            val param = UrlQueryParam("key1", values, stringifyQueryParam)
+            val expected = "key1=" + values.joinToString(",")
+            assertEquals(expected, stringifyForm(param))
+        }
+    }
+
+    @Nested
+    inner class StringifyExplodeTest {
+        @Test
+        fun `should return exploded form-encoded string for single value`() {
+            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
+            val expected = "key1=value1"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for multiple values`() {
+            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
+            val expected = "key1=value1&key1=value2&key1=value3"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for empty value list`() {
+            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
+            val expected = "key1="
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for key with special characters`() {
+            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
+            val expected = "key with spaces=value1"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for values with special characters`() {
+            val param = UrlQueryParam("key1", listOf("value with,comma", "value with&ampersand", "value with=equals"), stringifyQueryParam)
+            val expected = "key1=value with,comma&key1=value with&ampersand&key1=value with=equals"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for empty key`() {
+            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
+            val expected = "=value1&=value2"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for values with plus sign`() {
+            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
+            val expected = "key1=value+with+plus"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should return exploded form-encoded string for values with forward slash`() {
+            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
+            val expected = "key1=value/with/slash"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should handle very long key in exploded form`() {
+            val longKey = "a".repeat(1024)
+            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
+            val expected = "${longKey}=value1"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should handle very long value in exploded form`() {
+            val longValue = "b".repeat(1024)
+            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
+            val expected = "key1=${longValue}"
+            assertEquals(expected, stringifyExplode(param))
+        }
+
+        @Test
+        fun `should handle very large number of values in exploded form`() {
+            val values = List(1000) { "value$it" }
+            val param = UrlQueryParam("key1", values, stringifyQueryParam)
+            val expected = values.joinToString("&key1=", prefix = "key1=")
+            assertEquals(expected, stringifyExplode(param))
+        }
+    }
+
+    @Nested
+    inner class StringifySpaceDelimitedTest {
+        @Test
+        fun `should return space-delimited string for single value`() {
+            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
+            val expected = "key1=value1"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for multiple values`() {
+            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
+            val expected = "key1=value1%20value2%20value3"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for empty value list`() {
+            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
+            val expected = "key1="
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for key with special characters`() {
+            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
+            val expected = "key with spaces=value1"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for values with special characters`() {
+            val param = UrlQueryParam("key1", listOf("value with space", "value2"), stringifyQueryParam)
+            val expected = "key1=value with space%20value2"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for empty key`() {
+            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
+            val expected = "=value1%20value2"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for values with plus sign`() {
+            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
+            val expected = "key1=value+with+plus"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should return space-delimited string for values with forward slash`() {
+            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
+            val expected = "key1=value/with/slash"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should handle very long key in space delimited form`() {
+            val longKey = "a".repeat(1024)
+            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
+            val expected = "${longKey}=value1"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should handle very long value in space delimited form`() {
+            val longValue = "b".repeat(1024)
+            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
+            val expected = "key1=${longValue}"
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+
+        @Test
+        fun `should handle very large number of values in space delimited form`() {
+            val values = List(1000) { "value$it" }
+            val param = UrlQueryParam("key1", values, stringifyQueryParam)
+            val expected = "key1=" + values.joinToString("%20")
+            assertEquals(expected, stringifySpaceDelimited(param))
+        }
+    }
+
+    @Nested
+    inner class StringifyPipeDelimitedTest {
+        @Test
+        fun `should return pipe-delimited string for single value`() {
+            val param = UrlQueryParam("key1", listOf("value1"), stringifyQueryParam)
+            val expected = "key1=value1"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for multiple values`() {
+            val param = UrlQueryParam("key1", listOf("value1", "value2", "value3"), stringifyQueryParam)
+            val expected = "key1=value1|value2|value3"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for empty value list`() {
+            val param = UrlQueryParam("key1", emptyList(), stringifyQueryParam)
+            val expected = "key1="
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for key with special characters`() {
+            val param = UrlQueryParam("key with spaces", listOf("value1"), stringifyQueryParam)
+            val expected = "key with spaces=value1"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for values with special characters`() {
+            val param = UrlQueryParam("key1", listOf("value with|pipe", "value2"), stringifyQueryParam)
+            val expected = "key1=value with|pipe|value2"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for empty key`() {
+            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
+            val expected = "=value1|value2"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for values with plus sign`() {
+            val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
+            val expected = "key1=value+with+plus"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should return pipe-delimited string for values with forward slash`() {
+            val param = UrlQueryParam("key1", listOf("value/with/slash"), stringifyQueryParam)
+            val expected = "key1=value/with/slash"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should handle very long key in pipe delimited form`() {
+            val longKey = "a".repeat(1024)
+            val param = UrlQueryParam(longKey, listOf("value1"), stringifyQueryParam)
+            val expected = "${longKey}=value1"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should handle very long value in pipe delimited form`() {
+            val longValue = "b".repeat(1024)
+            val param = UrlQueryParam("key1", listOf(longValue), stringifyQueryParam)
+            val expected = "key1=${longValue}"
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+
+        @Test
+        fun `should handle very large number of values in pipe delimited form`() {
+            val values = List(1000) { "value$it" }
+            val param = UrlQueryParam("key1", values, stringifyQueryParam)
+            val expected = "key1=" + values.joinToString("|")
+            assertEquals(expected, stringifyPipeDelimited(param))
+        }
+    }
+
+    @Nested
+    inner class StringifyQueryParamTest {
+        @Test
+        fun `invoke should correctly convert UrlQueryParam to String using provided logic`() {
+            val customStringify = StringifyQueryParam { param ->
+                "${param.key}:${param.value.joinToString("-")}"
+            }
+            val param = UrlQueryParam("myKey", listOf("v1", "v2"), stringifyQueryParam)
+            val expectedString = "myKey:v1-v2"
+
+            val actualString = customStringify(param)
+
+            assertEquals(expectedString, actualString)
+        }
+
+        @Test
+        fun `invoke should handle empty values list`() {
+            val customStringify = StringifyQueryParam { param ->
+                "${param.key}:${param.value.joinToString("-")}"
+            }
+            val param = UrlQueryParam("myKey", emptyList(), stringifyQueryParam)
+            val expectedString = "myKey:"
+
+            val actualString = customStringify(param)
+
+            assertEquals(expectedString, actualString)
+        }
+
+        @Test
+        fun `invoke should handle empty key`() {
+            val customStringify = StringifyQueryParam { param ->
+                "${param.key}:${param.value.joinToString("-")}"
+            }
+            val param = UrlQueryParam("", listOf("v1", "v2"), stringifyQueryParam)
+            val expectedString = ":v1-v2"
+
+            val actualString = customStringify(param)
+
+            assertEquals(expectedString, actualString)
+        }
+
+        @Test
+        fun `invoke should handle custom encoding`() {
+            val customStringify = StringifyQueryParam { param ->
+                val encodedValues = param.value.map { it.replace(" ", "+") } // Encode space as +
+                "${param.key}=${encodedValues.joinToString(",")}"
+            }
+            val param = UrlQueryParam("key", listOf("value with space", "another value"), stringifyQueryParam)
+            val expected = "key=value+with+space,another+value"
+            assertEquals(expected, customStringify(param))
+        }
+
+        @Test
+        fun `invoke should add a prefix`() {
+            val customStringify = StringifyQueryParam { param ->
+                "prefix_${param.key}=${param.value.joinToString(",")}"
+            }
+            val param = UrlQueryParam("key", listOf("v1", "v2"), stringifyQueryParam)
+            val expected = "prefix_key=v1,v2"
+            assertEquals(expected, customStringify(param))
+        }
+    }
+}

--- a/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
+++ b/expediagroup-sdk-rest/src/test/kotlin/com/expediagroup/sdk/rest/util/UrlQueryParamUtilsTest.kt
@@ -4,7 +4,7 @@ import com.expediagroup.sdk.rest.model.UrlQueryParam
 import io.mockk.mockk
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertEquals // Import JUnit Jupiter Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 
 class UrlQueryParamUtilsTest {
     companion object {
@@ -45,13 +45,6 @@ class UrlQueryParamUtilsTest {
         fun `should return form-encoded string for values with special characters`() {
             val param = UrlQueryParam("key1", listOf("value with,comma", "value with&ampersand", "value with=equals"), stringifyQueryParam)
             val expected = "key1=value with,comma,value with&ampersand,value with=equals"
-            assertEquals(expected, stringifyForm(param))
-        }
-
-        @Test
-        fun `should return form-encoded string for empty key`() {
-            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
-            val expected = "=value1,value2"
             assertEquals(expected, stringifyForm(param))
         }
 
@@ -132,13 +125,6 @@ class UrlQueryParamUtilsTest {
         }
 
         @Test
-        fun `should return exploded form-encoded string for empty key`() {
-            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
-            val expected = "=value1&=value2"
-            assertEquals(expected, stringifyExplode(param))
-        }
-
-        @Test
         fun `should return exploded form-encoded string for values with plus sign`() {
             val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
             val expected = "key1=value+with+plus"
@@ -211,13 +197,6 @@ class UrlQueryParamUtilsTest {
         fun `should return space-delimited string for values with special characters`() {
             val param = UrlQueryParam("key1", listOf("value with space", "value2"), stringifyQueryParam)
             val expected = "key1=value with space%20value2"
-            assertEquals(expected, stringifySpaceDelimited(param))
-        }
-
-        @Test
-        fun `should return space-delimited string for empty key`() {
-            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
-            val expected = "=value1%20value2"
             assertEquals(expected, stringifySpaceDelimited(param))
         }
 
@@ -298,13 +277,6 @@ class UrlQueryParamUtilsTest {
         }
 
         @Test
-        fun `should return pipe-delimited string for empty key`() {
-            val param = UrlQueryParam("", listOf("value1", "value2"), stringifyQueryParam)
-            val expected = "=value1|value2"
-            assertEquals(expected, stringifyPipeDelimited(param))
-        }
-
-        @Test
         fun `should return pipe-delimited string for values with plus sign`() {
             val param = UrlQueryParam("key1", listOf("value+with+plus"), stringifyQueryParam)
             val expected = "key1=value+with+plus"
@@ -365,19 +337,6 @@ class UrlQueryParamUtilsTest {
             }
             val param = UrlQueryParam("myKey", emptyList(), stringifyQueryParam)
             val expectedString = "myKey:"
-
-            val actualString = customStringify(param)
-
-            assertEquals(expectedString, actualString)
-        }
-
-        @Test
-        fun `invoke should handle empty key`() {
-            val customStringify = StringifyQueryParam { param ->
-                "${param.key}:${param.value.joinToString("-")}"
-            }
-            val param = UrlQueryParam("", listOf("v1", "v2"), stringifyQueryParam)
-            val expectedString = ":v1-v2"
 
             val actualString = customStringify(param)
 


### PR DESCRIPTION
# Situation
The current implementation of URL query parameter handling in the SDK does not support various OpenAPI query parameter formats. This limitation affects the flexibility and compatibility of the SDK with different API specifications.

# Task
The objective is to enhance the SDK by adding support for multiple OpenAPI query parameter formats, including form, explode, space-delimited, and pipe-delimited formats. This will improve the SDK's ability to handle diverse API query parameter requirements.

# Action
- Introduced a new `UrlQueryParam` data class to represent URL query parameters.
- Implemented the `StringifyQueryParam` functional interface for converting `UrlQueryParam` to a string.
- Added utility functions (`stringifyForm`, `stringifyExplode`, `stringifySpaceDelimited`, `stringifyPipeDelimited`) to handle different query parameter formats.
- Created comprehensive unit tests for each query parameter format to ensure correct functionality.

# Testing
- Developed unit tests for the `UrlQueryParam` class to verify initialization and string conversion.
- Implemented tests for each query parameter format utility function to validate their output against expected results.
- Ensured edge cases such as empty keys, special characters, and large input sizes are covered in the tests.

# Results
- The SDK now supports multiple OpenAPI query parameter formats, enhancing its compatibility with various APIs.
- Unit tests confirm the correct implementation of the new features, ensuring reliability and robustness.
- The changes provide a more flexible and comprehensive solution for handling URL query parameters in the SDK.

# Notes
- Documentation updates may be required to reflect the new query parameter handling capabilities.
- Related issues and follow-up tasks include integrating these changes into the main SDK workflow and ensuring backward compatibility.
- Potential risks include the need for thorough testing in real-world scenarios to identify any unforeseen issues.