### PR TITLE
chore: add openapi generator templates

### DIFF
--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/api.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/api.mustache
@@ -1,0 +1,36 @@
+package com.expediagroup.sdk.{{namespace}}.operations
+
+import com.expediagroup.sdk.core.model.Operation
+
+{{#operations}}{{#operation}}
+    {{#bodyParam}}
+        import com.expediagroup.sdk.{{namespace}}.models.{{dataType}}
+    {{/bodyParam}}
+
+    {{#hasPathParams}}
+        import org.apache.commons.text.StringSubstitutor
+    {{/hasPathParams}}
+{{/operation}}{{/operations}}
+
+{{#operations}}
+    {{#operation}}
+        /**
+        * {{{summary}}}
+        {{#hasBodyParam}}
+            * @property requestBody [{{#bodyParam}}{{dataType}}{{/bodyParam}}]
+        {{/hasBodyParam}}
+        {{#hasNonBodyParams}}
+            * @property params [{{classname}}Params]
+        {{/hasNonBodyParams}}
+        */
+        class {{classname}}(
+            {{#hasNonBodyParams}}
+                params: {{classname}}Params,
+            {{/hasNonBodyParams}}
+            {{#hasBodyParam}}
+                requestBody: {{#bodyParam}}{{dataType}}{{/bodyParam}}{{^required}}?{{/required}},
+            {{/hasBodyParam}}
+        ) : {{>traits/inheritance}}
+        {{>traits/implementation}}
+    {{/operation}}
+{{/operations}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class.mustache
@@ -1,0 +1,134 @@
+import com.fasterxml.jackson.annotation.JsonProperty
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import javax.validation.Valid
+import javax.validation.Validation
+import org.hibernate.validator.constraints.Length
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator
+{{#discriminator}}
+    import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+    import com.fasterxml.jackson.annotation.JsonSubTypes
+    import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+    import com.fasterxml.jackson.annotation.JsonTypeInfo
+{{/discriminator}}
+
+import com.expediagroup.sdk.core.model.exception.client.PropertyConstraintViolationException
+
+/**
+ * {{{description}}}
+{{#vars}}
+ * @param {{{name}}} {{{description}}}
+{{/vars}}
+ */
+{{#discriminator}}
+@JsonIgnoreProperties(ignoreUnknown = true, value = ["{{discriminator.propertyName}}"])
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{discriminator.propertyName}}", visible = true)
+@JsonSubTypes(
+    {{#discriminator.mappedModels}}
+    Type(value = {{modelName}}::class, name = "{{mappingName}}"){{^-last}},{{/-last}}
+    {{/discriminator.mappedModels}}
+)
+{{/discriminator}}
+{{#nonPublicApi}}internal {{/nonPublicApi}}{{#discriminator}}interface {{/discriminator}}{{^discriminator}}data class {{/discriminator}}{{classname}}{{^discriminator}}(
+{{#allVars}}
+    {{#eliminateDiscriminators}}
+        {{#required}}{{>data_class_req_var}}{{/required}}{{^required}}{{>data_class_opt_var}}{{/required}}{{^-last}},{{/-last}}
+    {{/eliminateDiscriminators}}
+{{^-last}}
+
+{{/-last}}
+{{/allVars}}
+){{/discriminator}}{{#parent}}{{^serializableModel}}{{^parcelizeModels}}{{^isMap}} : {{{parent}}}{{#isArray}}(){{/isArray}}{{/isMap}}{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{^parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{^serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{#parent}}{{#serializableModel}}{{#parcelizeModels}} : {{{parent}}}{{#isMap}}(){{/isMap}}{{#isArray}}(){{/isArray}}, Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{^parcelizeModels}} : Serializable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{^serializableModel}}{{#parcelizeModels}} : Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}}{{^parent}}{{#serializableModel}}{{#parcelizeModels}} : Serializable, Parcelable{{/parcelizeModels}}{{/serializableModel}}{{/parent}} {
+{{^discriminator}}
+    {{#assignDiscriminators}}{{/assignDiscriminators}}
+{{/discriminator}}
+
+{{#discriminator}}{{#vars}}{{#required}}
+    {{>interface_req_var}}{{/required}}{{^required}}
+    {{>interface_opt_var}}{{/required}}{{/vars}}{{/discriminator}}
+{{^isKotlin}}
+    {{^discriminator}}
+    companion object {
+        @JvmStatic
+        fun builder() = Builder()
+    }
+
+    class Builder(
+        {{#allVars}}
+            {{#eliminateDiscriminators}}
+                private var {{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInCamelCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}? = null{{^-last}},{{/-last}}
+            {{/eliminateDiscriminators}}
+        {{/allVars}}
+    ) {
+        {{#allVars}}
+            {{#eliminateDiscriminators}}
+                fun {{{name}}}({{{name}}}: {{#isEnum}}{{#isArray}}kotlin.collections.List<{{classname}}.{{{nameInCamelCase}}}>{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}{{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{/required}}) = apply { this.{{{name}}} = {{{name}}} }
+            {{/eliminateDiscriminators}}
+        {{/allVars}}
+
+        fun build(): {{classname}} {
+            val instance = {{classname}}(
+                {{#allVars}}
+                    {{#eliminateDiscriminators}}
+                        {{{name}}} = {{{name}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
+                    {{/eliminateDiscriminators}}
+                {{/allVars}}
+            )
+
+            validate(instance)
+
+            return instance
+        }
+
+        private fun validate(instance: {{classname}}) {
+            val validator =
+                Validation
+                    .byDefaultProvider()
+                    .configure()
+                    .messageInterpolator(ParameterMessageInterpolator())
+                    .buildValidatorFactory()
+                    .validator
+
+            val violations = validator.validate(instance)
+
+            if (violations.isNotEmpty()) {
+                throw PropertyConstraintViolationException(
+                    constraintViolations = violations.map { "${it.propertyPath}: ${it.message}" }
+                )
+            }
+        }
+    }
+
+    fun toBuilder() = Builder(
+        {{#allVars}}
+            {{#eliminateDiscriminators}}
+                {{{name}}} = {{{name}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
+            {{/eliminateDiscriminators}}
+        {{/allVars}}
+    )
+    {{/discriminator}}
+{{/isKotlin}}
+{{#hasEnums}}
+    {{#vars}}
+        {{#isEnum}}
+
+    /**
+     * {{{description}}}
+     * Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+     */
+    enum class {{&nameInCamelCase}}(val value: {{#isArray}}{{{items.dataType}}}{{/isArray}}{{^isArray}}{{dataType}}{{/isArray}}) {
+    {{#allowableValues}}
+        {{#enumVars}}
+        @JsonProperty({{{value}}})
+        {{&name}}({{{value}}}){{^-last}},
+        {{/-last}}{{#-last}};{{/-last}}
+        {{/enumVars}}
+    {{/allowableValues}}
+    }
+        {{/isEnum}}
+    {{/vars}}
+{{/hasEnums}}
+}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class_opt_var.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class_opt_var.mustache
@@ -1,0 +1,9 @@
+{{#description}}
+/* {{{.}}} */
+{{/description}}
+{{#deprecated}}
+    @Deprecated(message = "This property is deprecated.")
+{{/deprecated}}
+{{#lambda.indented}}@JsonProperty("{{baseName}}"){{/lambda.indented}}
+{{^format}}{{#lambda.indented}}{{>models/constraints}}{{/lambda.indented}}{{/format}}{{#format}}{{#isString}}{{#lambda.indented}}{{>models/constraints}}{{/lambda.indented}}{{/isString}}{{/format}}
+    {{#isInherited}}override {{/isInherited}}{{>modelMutable}} {{{name}}}: {{#isArray}}{{#isList}}{{#uniqueItems}}kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}Set{{/uniqueItems}}{{^uniqueItems}}kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}List{{/uniqueItems}}{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{^items.isEnum}}{{{items.dataType}}}{{/items.isEnum}}{{#items.isEnum}}{{classname}}.{{{nameInCamelCase}}}{{/items.isEnum}}>{{/isArray}}{{^isEnum}}{{^isArray}}{{{dataType}}}{{/isArray}}{{/isEnum}}{{#isEnum}}{{^isArray}}{{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{^isArray}}{{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}{{/isArray}}{{/isEnum}}? = {{^defaultValue}}null{{/defaultValue}}{{#defaultValue}}{{^isNumber}}{{{defaultValue}}}{{/isNumber}}{{#isNumber}}{{^multiplatform}}{{{dataType}}}("{{{defaultValue}}}"){{/multiplatform}}{{#multiplatform}}({{{defaultValue}}}).toDouble(){{/multiplatform}}{{/isNumber}}{{/defaultValue}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class_req_var.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/data_class_req_var.mustache
@@ -1,0 +1,53 @@
+{{#description}}
+/* {{{.}}} */
+{{/description}}
+{{#deprecated}}
+    @Deprecated(message = "This property is deprecated.")
+{{/deprecated}}
+{{#lambda.indented}}@JsonProperty("{{baseName}}"){{/lambda.indented}}
+{{^format}}
+    {{#lambda.indented}}{{>models/constraints}}{{/lambda.indented}}
+{{/format}}
+{{#format}}
+    {{#isString}}{{#lambda.indented}}{{>models/constraints}}{{/lambda.indented}}{{/isString}}
+{{/format}}
+{{#isInherited}}override {{/isInherited}}{{>modelMutable}} {{{name}}}:
+{{#isArray}}
+    {{#isList}}
+        {{#uniqueItems}}kotlin.collections.
+            {{#modelMutable}}Mutable{{/modelMutable}}Set
+        {{/uniqueItems}}
+        {{^uniqueItems}}kotlin.collections.
+            {{#modelMutable}}Mutable{{/modelMutable}}List
+        {{/uniqueItems}}
+    {{/isList}}
+    {{^isList}}
+        kotlin.Array
+    {{/isList}}<
+        {{^items.isEnum}}
+            {{{items.dataType}}}
+        {{/items.isEnum}}
+        {{#items.isEnum}}
+            {{classname}}.{{{nameInCamelCase}}}
+        {{/items.isEnum}}>
+{{/isArray}}
+{{^isEnum}}
+    {{^isArray}}{{{dataType}}}{{/isArray}}
+{{/isEnum}}
+{{#isEnum}}
+    {{^isArray}}
+        {{^isInherited}}{{classname}}.{{{nameInCamelCase}}}{{/isInherited}}
+    {{/isArray}}
+    {{^isArray}}
+        {{#isInherited}}{{{parent}}}.{{{nameInCamelCase}}}{{/isInherited}}
+    {{/isArray}}
+{{/isEnum}}
+{{#defaultValue}} =
+    {{^isNumber}}
+        {{{defaultValue}}}
+    {{/isNumber}}
+    {{#isNumber}}
+        {{^multiplatform}}{{{dataType}}}("{{{defaultValue}}}"){{/multiplatform}}
+        {{#multiplatform}}({{{defaultValue}}}).toDouble(){{/multiplatform}}
+    {{/isNumber}}
+{{/defaultValue}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/enum_class.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/enum_class.mustache
@@ -1,0 +1,14 @@
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+* {{{description}}}
+* Values: {{#allowableValues}}{{#enumVars}}{{&name}}{{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
+*/
+enum class {{classname}}(val value: {{dataType}}) {
+{{#allowableValues}}
+    {{#enumVars}}
+    @JsonProperty({{{value}}})
+    {{&name}}({{{value}}}){{^-last}},{{/-last}}
+    {{/enumVars}}
+{{/allowableValues}}
+}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/imports/domain.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/imports/domain.mustache
@@ -1,0 +1,12 @@
+import {{packageName}}.models.*
+
+{{#apiInfo}}
+    {{#apis}}{{#operations}}{{#operation}}
+        import {{packageName}}.operations.{{classname}}
+        import {{packageName}}.operations.{{classname}}Params
+    {{/operation}}{{/operations}}{{/apis}}
+    {{#defineApiExceptions}}
+        import {{packageName}}.models.exception.ExpediaGroupApi{{dataType}}Exception
+        import {{packageName}}.models.exception.ErrorObjectMapper
+    {{/defineApiExceptions}}
+{{/apiInfo}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/interface_opt_var.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/interface_opt_var.mustache
@@ -1,0 +1,4 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+{{>modelMutable}} {{{name}}}: {{#isArray}}{{#isList}}kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{^items.isEnum}}{{^items.isPrimitiveType}}{{^items.isModel}}{{#kotlinx_serialization}}@Contextual {{/kotlinx_serialization}}{{/items.isModel}}{{/items.isPrimitiveType}}{{{items.dataType}}}{{/items.isEnum}}{{#items.isEnum}}{{classname}}.{{{nameInCamelCase}}}{{/items.isEnum}}>{{/isArray}}{{^isEnum}}{{^isArray}}{{{dataType}}}{{/isArray}}{{/isEnum}}{{#isEnum}}{{^isArray}}{{classname}}.{{{nameInCamelCase}}}{{/isArray}}{{/isEnum}}?

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/interface_req_var.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/interface_req_var.mustache
@@ -1,0 +1,5 @@
+{{#description}}
+    /* {{{.}}} */
+{{/description}}
+
+{{>modelMutable}} {{{name}}}: {{#isArray}}{{#isList}}kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}List{{/isList}}{{^isList}}kotlin.Array{{/isList}}<{{^items.isEnum}}{{^items.isPrimitiveType}}{{^items.isModel}}{{#kotlinx_serialization}}@Contextual {{/kotlinx_serialization}}{{/items.isModel}}{{/items.isPrimitiveType}}{{{items.dataType}}}{{/items.isEnum}}{{#items.isEnum}}{{classname}}.{{{nameInCamelCase}}}{{/items.isEnum}}>{{/isArray}}{{^isEnum}}{{^isArray}}{{{dataType}}}{{/isArray}}{{/isEnum}}{{#isEnum}}{{^isArray}}{{classname}}.{{{nameInCamelCase}}}{{/isArray}}{{/isEnum}}{{#isNullable}}?{{/isNullable}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/licenseinfo.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/licenseinfo.mustache
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2022 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/models/constraints.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/models/constraints.mustache
@@ -1,0 +1,41 @@
+{{#pattern}}@field:Pattern(regexp = "{{{pattern}}}"){{/pattern}}
+{{#maxLength}}
+    {{#minLength}}
+        @field:Length(min = {{minLength}}, max = {{maxLength}})
+    {{/minLength}}
+{{/maxLength}}
+{{^maxLength}}
+    {{#minLength}}
+        @field:Length(min = {{minLength}})
+    {{/minLength}}
+{{/maxLength}}
+{{#maxLength}}
+    {{^minLength}}
+        @field:Length(max = {{maxLength}})
+    {{/minLength}}
+{{/maxLength}}
+{{#maxItems}}
+    {{#minItems}}
+        @field:Size(min = {{minItems}}, max = {{maxItems}})
+    {{/minItems}}
+{{/maxItems}}
+{{^maxItems}}
+    {{#minItems}}
+        @field:Size(min = {{minItems}})
+    {{/minItems}}
+{{/maxItems}}
+{{#maxItems}}
+    {{^minItems}}
+        @field:Size(max = {{maxItems}})
+    {{/minItems}}
+{{/maxItems}}
+{{#minimum}}
+    @field:Min({{minimum}}{{#exclusiveMinimum}} + 1{{/exclusiveMinimum}})
+{{/minimum}}
+{{#maximum}}
+    @field:Max({{maximum}}{{#exclusiveMaximum}} - 1{{/exclusiveMaximum}})
+{{/maximum}}
+{{#required}}
+    @field:NotNull
+{{/required}}
+{{^isEnum}}@field:Valid{{/isEnum}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/operation_params.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/operation_params.mustache
@@ -1,0 +1,173 @@
+{{#operations}}
+    {{#operation}}
+        {{#hasNonBodyParams}}
+            package com.expediagroup.sdk.{{namespace}}.operations
+
+            import com.expediagroup.sdk.core.model.exception.client.PropertyConstraintViolationException
+
+            import com.fasterxml.jackson.annotation.JsonProperty
+            import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+            import com.expediagroup.sdk.core.http.Headers
+            import com.expediagroup.sdk.rest.model.UrlQueryParam
+            import com.expediagroup.sdk.rest.util.*
+
+            import javax.validation.constraints.Max
+            import javax.validation.constraints.Min
+            import javax.validation.constraints.NotNull
+            import javax.validation.constraints.Pattern
+            import javax.validation.constraints.Size
+            import javax.validation.Valid
+            import javax.validation.Validation
+
+            import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator
+
+            /**
+            {{#nonBodyParams}}
+                {{#params}}
+                    * @property {{{paramName}}} {{{description}}}
+                {{/params}}
+            {{/nonBodyParams}}
+            */
+            @JsonDeserialize(builder = {{classname}}Params.Builder::class)
+            data class {{classname}}Params(
+                {{#nonBodyParams}}
+                    {{#params}}
+                        {{>models/constraints}}
+                        {{>modelMutable}} {{>client/apiParam}}{{^-last}}, {{/-last}}
+                    {{/params}}
+                {{/nonBodyParams}}
+            ) {
+                companion object {
+                    @JvmStatic
+                    fun builder() = Builder()
+                }
+
+                {{#nonBodyParams}}
+                    {{#params}}
+                        {{#isEnum}}
+                            enum class {{enumName}}(
+                                val value:
+                                {{#isContainer}}{{{items.dataType}}}{{/isContainer}}
+                                {{^isContainer}}{{dataType}}{{/isContainer}}
+                            ) {
+                                {{#allowableValues}}
+                                    {{#enumVars}}
+                                        {{name}}({{{value}}})
+                                        {{^-last}},{{/-last}}
+                                    {{/enumVars}}
+                                {{/allowableValues}}
+                            }
+                        {{/isEnum}}
+                    {{/params}}
+                {{/nonBodyParams}}
+
+                class Builder(
+                    {{#nonBodyParams}}
+                        {{#params}}
+                            @JsonProperty("{{{baseName}}}") private var {{{paramName}}}: {{>partials/datatype}}? = null
+                            {{^-last}},{{/-last}}
+                        {{/params}}
+                    {{/nonBodyParams}}
+                ) {
+                    {{#nonBodyParams}}
+                        {{#params}}
+                            /**
+                            * @param {{{paramName}}} {{{description}}}
+                            */
+                            fun {{{paramName}}}({{{paramName}}}: {{>partials/datatype}}) = apply { this.{{{paramName}}} = {{{paramName}}} }
+                        {{/params}}
+                    {{/nonBodyParams}}
+
+                    fun build(): {{classname}}Params {
+                        val params = {{classname}}Params(
+                            {{#nonBodyParams}}
+                                {{#params}}
+                                    {{{paramName}}} = {{{paramName}}}{{#required}}!!{{/required}}{{^-last}},{{/-last}}
+                                {{/params}}
+                            {{/nonBodyParams}}
+                        )
+
+                        validate(params)
+
+                        return params
+                    }
+
+                    private fun validate(params: {{classname}}Params) {
+                        val validator =
+                            Validation
+                                .byDefaultProvider()
+                                .configure()
+                                .messageInterpolator(ParameterMessageInterpolator())
+                                .buildValidatorFactory()
+                                .validator
+
+                        val violations = validator.validate(params)
+
+                        if (violations.isNotEmpty()) {
+                            throw PropertyConstraintViolationException(
+                                constraintViolations = violations.map { "${it.propertyPath}: ${it.message}" }
+                            )
+                        }
+                    }
+                }
+
+                fun toBuilder() = Builder(
+                    {{#nonBodyParams}}
+                        {{#params}}
+                            {{{paramName}}} = {{{paramName}}}{{^-last}},{{/-last}}
+                        {{/params}}
+                    {{/nonBodyParams}}
+                )
+
+                {{#hasHeaderParams}}fun getHeaders(): Headers {
+                    return Headers.builder().apply {
+                        {{#headerParams}}
+                            {{paramName}}?.let {
+                                add("{{baseName}}", it{{#isEnum}}.value{{/isEnum}})
+                            }
+                        {{/headerParams}}
+                        {{#responses}}
+                            {{#httpAcceptHeader}}
+                                add("Accept", "{{mediaTypes}}")
+                            {{/httpAcceptHeader}}
+                        {{/responses}}
+                    }
+                }{{/hasHeaderParams}}
+
+            {{#hasQueryParams}}fun getQueryParams(): List<UrlQueryParam> =
+                    buildList {
+                        {{#queryParams}}
+                            {{paramName}}?.let {
+                                val key = {{paramName}}
+                                val value = buildList {
+                                    {{#isContainer}}
+                                        addAll("it{{#isEnum}}.map { it.value }{{/isEnum}})
+                                    {{/isContainer}}
+                                    {{^isContainer}}
+                                        add("it{{#isEnum}}.value{{/isEnum}}{{^isString}}.toString(){{/isString}})
+                                    {{/isContainer}}
+                                }
+
+                                add(UrlQueryParam(
+                                    key = key,
+                                    value = value
+                                    stringify = stringifyExplode
+                                ))
+                            }
+                        {{/queryParams}}
+                    }{{/hasQueryParams}}
+
+                {{#hasPathParams}}fun getPathParams() : Map<String, String> {
+                    return buildMap {
+                        {{#pathParams}}
+                            {{paramName}}?.also {
+                                put("{{baseName}}", {{paramName}}{{#isEnum}}.value{{/isEnum}})
+                            }
+                        {{/pathParams}}
+                    }
+                }{{/hasPathParams}}
+            }
+        {{/hasNonBodyParams}}
+    {{/operation}}
+{{/operations}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/partials/datatype.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/partials/datatype.mustache
@@ -1,0 +1,16 @@
+{{#isContainer}}
+    {{#uniqueItems}}
+        kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}Set
+    {{/uniqueItems}}
+    {{^uniqueItems}}
+        kotlin.collections.{{#modelMutable}}Mutable{{/modelMutable}}List
+    {{/uniqueItems}}
+    <
+        {{#items.isEnum}}{{classname}}Params.{{{enumName}}}{{/items.isEnum}}
+        {{^items.isEnum}}{{{items.dataType}}}{{/items.isEnum}}
+    >
+{{/isContainer}}
+{{^isContainer}}
+    {{#isEnum}}{{classname}}Params.{{{enumName}}}{{/isEnum}}
+    {{^isEnum}}{{{dataType}}}{{/isEnum}}
+{{/isContainer}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/traits/implementation.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/traits/implementation.mustache
@@ -1,0 +1,29 @@
+override fun getHttpMethod(): String = "{{httpMethod}}"
+
+override fun getRequestInfo(): OperationRequestTrait = this
+
+override fun getUrlPath(): String {
+    var url = {{{path}}}
+
+    {{#hasPathParms}}{{#pathParams}}
+        url = url.replace(
+            oldValue = "{{baseName}}",
+            newValue = {{paramName}}{{#isEnum}}.value{{/isEnum}},
+            ignoreCase = true
+        )
+    {{/pathParams}}{{/hasPathParms}}
+
+    return url
+}
+
+{{#hasBodyParam}}{{#bodyParam}}
+override fun getRequestBody(): {{{dataType}}} = requestBody
+{{/bodyParam}}{{/hasBodyParam}}
+
+{{#customReturnType}}
+override fun getTypeIdentifier(): TypeReference<{{{datatype}}}> = jacksonTypeRef()
+{{/customReturnType}}
+
+{{#hasHeaderParams}}
+override fun getHeaders(): Headers = this.params.getHeaders()
+{{/hasHeaderParams}}

--- a/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/traits/inheritance.mustache
+++ b/expediagroup-sdk-rest/src/main/resources/templates/expediagroup-sdk/traits/inheritance.mustache
@@ -1,0 +1,8 @@
+OperationRequestTrait,
+UrlPathTrait,
+{{#hasBodyParam}}{{#bodyParam}}, OperationRequestBodyTrait<{{dataType}}>{{/bodyParam}}{{/hasBodyParam}}
+{{#customReturnType}}, JacksonModelOperationResponseBodyTrait<{{{returnType}}}{{/customReturnType}}
+{{^returnType}}, OperationNoResponseBodyTrait{{/returnType}}
+{{#hasConsumes}}, ContentTypeTrait{{/hasConsumes}}
+{{#hasQueryParams}}, UrlQueryParamsTrait{{/hasQueryParams}}
+{{#hasHeaderParams}}, HeadersTrait{{/hasHeaderParams}}


### PR DESCRIPTION
# Situation
The project needs to add OpenAPI code generation templates to support generating Kotlin code for the Expedia Group SDK REST module. Currently, there are no templates available to generate the necessary code structures for API operations, data classes, and enums.

# Task
Create and implement Mustache templates for generating Kotlin code that aligns with the SDK's architecture and coding standards. The templates need to support:
- API operation classes
- Data classes with validation
- Enum classes
- Parameter classes with builder pattern
- Request/response traits

# Action
Copied templates from the [expediagroup-java-sdk](https://github.com/ExpediaGroup/expediagroup-java-sdk/tree/c0f7e3f399d444329b8aa8c3462680be53b47788/generator/openapi/src/main/resources/templates/expediagroup-sdk) repository. Did the following modifications:
- Deleted `client.mustache` and all related, embedded templates.
- Created `traits/inheritance.mustache` and `traits/implementation.mustache` for trait-related implementation. 

# Testing
Verified locally.

# Results
- Complete set of templates for generating type-safe Kotlin code
- Support for Jackson annotations and serialization
- Built-in validation using javax.validation
- Proper handling of nullable types and collections
- Generated code follows Kotlin best practices

# Notes
**NaN**